### PR TITLE
feature!: Add generic implementation of Must()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,6 @@ jobs:
     with:
       go-version: "1.22.5"
       build-tags: '[""]'
+      golangci-lint-version: "1.58.1"
   semantic-titles:
     uses: cccteam/github-workflows/.github/workflows/semantic-pull-request-title.yml@v4.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,9 @@ concurrency:
 
 jobs:
   golang-ci:
-    uses: cccteam/github-workflows/.github/workflows/golang-ci.yml@v4.1.0
+    uses: cccteam/github-workflows/.github/workflows/golang-ci.yml@v5.0.0
     with:
-      go-version: "1.22.5"
       build-tags: '[""]'
       golangci-lint-version: "v1.58.1"
   semantic-titles:
-    uses: cccteam/github-workflows/.github/workflows/semantic-pull-request-title.yml@v4.1.0
+    uses: cccteam/github-workflows/.github/workflows/semantic-pull-request-title.yml@v5.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
     with:
       go-version: "1.22.5"
       build-tags: '[""]'
-      golangci-lint-version: "1.58.1"
+      golangci-lint-version: "v1.58.1"
   semantic-titles:
     uses: cccteam/github-workflows/.github/workflows/semantic-pull-request-title.yml@v4.1.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters-settings:
           - $gostd
           - github.com/go-playground/errors/v5
           - github.com/gofrs/uuid
+          - github.com/google/go-cmp/cmp
   funlen:
     lines: 100
     statements: 50

--- a/uuid.go
+++ b/uuid.go
@@ -63,16 +63,6 @@ func (u *UUID) UnmarshalText(text []byte) error {
 	return nil
 }
 
-// UUIDMustParse parses a string into a UUID, panicking if the string is not a valid UUID.
-func UUIDMustParse(s string) UUID {
-	uid, err := UUIDFromString(s)
-	if err != nil {
-		panic(err)
-	}
-
-	return uid
-}
-
 type NullUUID struct {
 	UUID
 	Valid bool

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -1,6 +1,8 @@
 package ccc
 
 import (
+	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -14,6 +16,47 @@ func Must[T any](value T, err error) T {
 	}
 
 	return value
+}
+
+func TestMust_string(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		value string
+		err   error
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      string
+		wantPanic bool
+	}{
+		{
+			name: "No error",
+			args: args{value: "test", err: nil},
+			want: "test",
+		},
+		{
+			name:      "With error",
+			args:      args{value: "test", err: errors.New("test")},
+			wantPanic: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			defer func() {
+				if r := recover(); (r != nil) != tt.wantPanic {
+					t.Errorf("Must() panic = %v, wantPanic %v", r, tt.wantPanic)
+				}
+			}()
+
+			if got := Must(tt.args.value, tt.args.err); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Must() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestNewUUID(t *testing.T) {

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -7,6 +7,15 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+// Must is a helper function to avoid the need to check for errors.
+func Must[T any](value T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+
+	return value
+}
+
 func TestNewUUID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR implements a Generic `Must()` and removes a specific Must implementation for parsing UUID from a string.

`Must()` was also moved into the test file so it can not be used in production code.