### PR TITLE
feature: Add support for 'sort' query parameter

### DIFF
--- a/resource/query_decoder_test.go
+++ b/resource/query_decoder_test.go
@@ -230,7 +230,7 @@ func TestQueryDecoder_parseQuery(t *testing.T) {
 				t.Fatalf("NewQueryDecoder should not fail with default setup for test case %s: %v", tt.name, err)
 			}
 
-			columnFields, searchSet, parsedAST, err := decoder.parseQuery(tt.queryValues)
+			columnFields, _, searchSet, parsedAST, err := decoder.parseQuery(tt.queryValues) // Added _ for sortFields
 
 			if tt.wantErr {
 				if err == nil {

--- a/resource/queryset_test.go
+++ b/resource/queryset_test.go
@@ -1,6 +1,9 @@
 package resource
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/cccteam/ccc/accesstypes"
 )
 
@@ -16,100 +19,216 @@ func (SpannerStruct) Resource() accesstypes.Resource {
 	return "SpannerStructs"
 }
 
-// func TestQuerySet_Columns(t *testing.T) {
-// 	t.Parallel()
+// SortTestResource is used for testing sorting functionality.
+type SortTestResource struct {
+	ID   string `spanner:"item_id" db:"item_id"`
+	Name string `spanner:"item_name" db:"item_name"`
+	Date string `spanner:"creation_date" db:"creation_date"`
+}
 
-// 	type args struct {
-// 		patchSet *resource.PatchSet
-// 	}
-// 	tests := []struct {
-// 		name string
-// 		args args
-// 		want Columns
-// 	}{
-// 		{
-// 			name: "multiple fields in patchSet",
-// 			args: args{
-// 				patchSet: resource.NewPatchSet(resource.NewRow[SpannerStruct]()).
-// 					Set("Field2", "apple").
-// 					Set("Field3", 10),
-// 			},
-// 			want: "fieldtwo, field3",
-// 		},
-// 		{
-// 			name: "multiple fields not in sorted order",
-// 			args: args{
-// 				patchSet: resource.NewPatchSet(resource.NewRow[SpannerStruct]()).
-// 					Set("Field4", "apple").
-// 					Set("Field5", "bannana"),
-// 			},
-// 			want: "field5, field4",
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		tt := tt
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			t.Parallel()
+func (SortTestResource) Resource() accesstypes.Resource {
+	return "SortTestResources"
+}
 
-// 			got, _ := tm.Columns(tt.args.patchSet.QuerySet())
-// 			if got != tt.want {
-// 				t.Errorf("Patcher.Columns() = (%v),  want (%v)", got, tt.want)
-// 			}
-// 		})
-// 	}
-// }
+func (s SortTestResource) DefaultConfig() Config { // Changed to Config
+	// Provide a default Config. The DBType might be overridden by tests,
+	// but NewResourceMetadata expects a Config from this method.
+	return Config{
+		DBType: SpannerDBType, // Default DBType for the config
+		// TrackChanges: false, // Default if needed
+		// ChangeTrackingTable: "", // Default if needed
+	}
+}
 
-// type PostgresStruct struct {
-// 	Field1 string `db:"field1"`
-// 	Field2 string `db:"fieldtwo"`
-// 	Field3 int    `db:"field3"`
-// 	Field5 string `db:"field5"`
-// 	Field4 string `db:"field4"`
-// }
+func TestQuerySet_SpannerStmt_OrderBy(t *testing.T) {
+	rMetaSpanner := NewResourceMetadata[SortTestResource]()
+	// Ensure the rMeta has the correct dbType for Spanner tests,
+	// overriding or confirming what DefaultConfig might have set.
+	rMetaSpanner.dbType = SpannerDBType
 
-// func (PostgresStruct) Resource() accesstypes.Resource {
-// 	return "PostgresStructs"
-// }
+	tests := []struct {
+		name                 string
+		sortFields           []SortField
+		searchActive         bool // New field to indicate if search should be set
+		wantQueryContains    string
+		wantErrorMsgContains string // New field for specific error message
+		wantErr              bool
+		assertFunc           func(t *testing.T, sql string, wantContains string)
+	}{
+		{
+			name: "no sort fields",
+			sortFields:        []SortField{},
+			wantQueryContains: "ORDER BY", // Expect ORDER BY to be absent
+			assertFunc: func(t *testing.T, sql string, wantContains string) {
+				if strings.Contains(sql, wantContains) {
+					t.Errorf("Expected SQL NOT to contain '%s', but got: %s", wantContains, sql)
+				}
+			},
+		},
+		{
+			name:              "single field ascending",
+			sortFields:        []SortField{{Field: "Name", Direction: SortAscending}},
+			wantQueryContains: "ORDER BY `item_name` ASC",
+		},
+		{
+			name:              "single field descending",
+			sortFields:        []SortField{{Field: "Date", Direction: SortDescending}},
+			wantQueryContains: "ORDER BY `creation_date` DESC",
+		},
+		{
+			name:              "multiple fields mixed directions",
+			sortFields:        []SortField{{Field: "Name", Direction: SortAscending}, {Field: "Date", Direction: SortDescending}},
+			wantQueryContains: "ORDER BY `item_name` ASC, `creation_date` DESC",
+		},
+		{
+			name:              "sorting by ID field",
+			sortFields:        []SortField{{Field: "ID", Direction: SortDescending}},
+			wantQueryContains: "ORDER BY `item_id` DESC",
+		},
+		{
+			name:       "invalid sort field",
+			sortFields:           []SortField{{Field: "InvalidField", Direction: SortAscending}},
+			wantErr:              true, // Expect error from buildOrderByClause
+			wantErrorMsgContains: "not found in resource metadata", // buildOrderByClause error
+		},
+		{
+			name:                 "error sort with search spanner",
+			sortFields:           []SortField{{Field: "Name", Direction: SortAscending}},
+			searchActive:         true,
+			wantErr:              true,
+			wantErrorMsgContains: "sorting ('sort=' parameter) cannot be used in conjunction with search parameters",
+		},
+	}
 
-// func TestPatcher_Postgres_Columns(t *testing.T) {
-// 	t.Parallel()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			qSet := NewQuerySet(rMetaSpanner)
+			qSet.AddField("ID") // Add a default field to make the SELECT valid
 
-// 	type args struct {
-// 		patchSet *resource.PatchSet
-// 	}
-// 	tests := []struct {
-// 		name string
-// 		args args
-// 		want Columns
-// 	}{
-// 		{
-// 			name: "multiple fields in patchSet",
-// 			args: args{
-// 				patchSet: resource.NewPatchSet(resource.NewRow[PostgresStruct]()).
-// 					Set("Field2", "apple").
-// 					Set("Field3", 10),
-// 			},
-// 			want: `"fieldtwo", "field3"`,
-// 		},
-// 		{
-// 			name: "multiple fields not in sorted order",
-// 			args: args{
-// 				patchSet: resource.NewPatchSet(resource.NewRow[PostgresStruct]()).
-// 					Set("Field4", "apple").
-// 					Set("Field5", "bannana"),
-// 			},
-// 			want: `"field5", "field4"`,
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		tt := tt
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			t.Parallel()
+			if tc.searchActive {
+				qSet.SetSearchParam(NewSearch(SubString, map[SearchKey]string{SearchKey("AnyField"): "anyValue"}))
+			}
+			qSet.SetSortFields(tc.sortFields)
+			stmt, err := qSet.SpannerStmt()
 
-// 			got, _ := tm.Columns(tt.args.patchSet.QuerySet())
-// 			if got != tt.want {
-// 				t.Errorf("Patcher.Columns() = (%v),  want (%v)", got, tt.want)
-// 			}
-// 		})
-// 	}
-// }
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("Expected an error, but got none")
+				} else if tc.wantErrorMsgContains != "" && !strings.Contains(err.Error(), tc.wantErrorMsgContains) {
+					t.Errorf("SpannerStmt() error = %v, want error message containing %q", err, tc.wantErrorMsgContains)
+				}
+				return // Test finished if error was expected
+			}
+			if err != nil {
+				t.Fatalf("SpannerStmt() error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			sql := stmt.Statement.SQL // Access as a field, not a function
+			if tc.assertFunc != nil {
+				tc.assertFunc(t, sql, tc.wantQueryContains)
+			} else {
+				if !strings.Contains(sql, tc.wantQueryContains) {
+					t.Errorf("SpannerStmt() SQL = \n%s\nWant to contain:\n%s", sql, tc.wantQueryContains)
+				}
+			}
+		})
+	}
+}
+
+func TestQuerySet_PostgresStmt_OrderBy(t *testing.T) {
+	rMetaPostgres := NewResourceMetadata[SortTestResource]()
+	// Ensure the rMeta has the correct dbType for Postgres tests.
+	rMetaPostgres.dbType = PostgresDBType
+
+	tests := []struct {
+		name                 string
+		sortFields           []SortField
+		searchActive         bool // New field
+		wantQueryContains    string
+		wantErrorMsgContains string // New field
+		wantErr              bool
+		assertFunc           func(t *testing.T, sql string, wantContains string)
+	}{
+		{
+			name: "no sort fields",
+			sortFields:        []SortField{},
+			wantQueryContains: "ORDER BY", // Expect ORDER BY to be absent
+			assertFunc: func(t *testing.T, sql string, wantContains string) {
+				if strings.Contains(sql, wantContains) {
+					t.Errorf("Expected SQL NOT to contain '%s', but got: %s", wantContains, sql)
+				}
+			},
+		},
+		{
+			name:              "single field ascending",
+			sortFields:        []SortField{{Field: "Name", Direction: SortAscending}},
+			wantQueryContains: `ORDER BY "item_name" ASC`,
+		},
+		{
+			name:              "single field descending",
+			sortFields:        []SortField{{Field: "Date", Direction: SortDescending}},
+			wantQueryContains: `ORDER BY "creation_date" DESC`,
+		},
+		{
+			name:              "multiple fields mixed directions",
+			sortFields:        []SortField{{Field: "Name", Direction: SortAscending}, {Field: "Date", Direction: SortDescending}},
+			wantQueryContains: `ORDER BY "item_name" ASC, "creation_date" DESC`,
+		},
+		{
+			name:              "sorting by ID field",
+			sortFields:        []SortField{{Field: "ID", Direction: SortDescending}},
+			wantQueryContains: `ORDER BY "item_id" DESC`,
+		},
+		{
+			name:       "invalid sort field",
+			sortFields:           []SortField{{Field: "InvalidField", Direction: SortAscending}},
+			wantErr:              true, // Expect error from buildOrderByClause
+			wantErrorMsgContains: "not found in resource metadata", // buildOrderByClause error
+		},
+		{
+			name:                 "error sort with search postgres",
+			sortFields:           []SortField{{Field: "Name", Direction: SortAscending}},
+			searchActive:         true,
+			wantErr:              true,
+			wantErrorMsgContains: "sorting ('sort=' parameter) cannot be used in conjunction with search parameters",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			qSet := NewQuerySet(rMetaPostgres)
+			qSet.AddField("ID") // Add a default field to make the SELECT valid
+
+			if tc.searchActive {
+				qSet.SetSearchParam(NewSearch(SubString, map[SearchKey]string{SearchKey("AnyField"): "anyValue"}))
+			}
+			qSet.SetSortFields(tc.sortFields)
+			stmt, err := qSet.PostgresStmt()
+
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("Expected an error, but got none")
+				} else if tc.wantErrorMsgContains != "" && !strings.Contains(err.Error(), tc.wantErrorMsgContains) {
+					t.Errorf("PostgresStmt() error = %v, want error message containing %q", err, tc.wantErrorMsgContains)
+				}
+				return // Test finished if error was expected
+			}
+			if err != nil {
+				t.Fatalf("PostgresStmt() error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			sql := stmt.SQL
+			if tc.assertFunc != nil {
+				tc.assertFunc(t, sql, tc.wantQueryContains)
+			} else {
+				if !strings.Contains(sql, tc.wantQueryContains) {
+					t.Errorf("PostgresStmt() SQL = \n%s\nWant to contain:\n%s", sql, tc.wantQueryContains)
+				}
+			}
+		})
+	}
+}
+
+// Commenting out old tests for now, they can be updated or removed later
+// func TestQuerySet_Columns(t *testing.T) { ... }
+// func TestPatcher_Postgres_Columns(t *testing.T) { ... }

--- a/resource/types.go
+++ b/resource/types.go
@@ -36,6 +36,20 @@ type TypescriptData struct {
 	Domains               []accesstypes.PermissionScope
 }
 
+// SortDirection defines the sort direction for a field.
+type SortDirection string
+
+const (
+	SortAscending  SortDirection = "asc"
+	SortDescending SortDirection = "desc"
+)
+
+// SortField represents a field to sort by, including the field name and sort direction.
+type SortField struct {
+	Field     string
+	Direction SortDirection
+}
+
 var _ FieldDefaultFunc = CommitTimestamp
 
 func CommitTimestamp(_ context.Context, _ TxnBuffer) (any, error) {


### PR DESCRIPTION
This commit introduces functionality to sort data returned from APIs by using a 'sort' HTTP query parameter.

The 'sort' parameter allows clients to specify the order of results based on one or more resource fields. The syntax is: `sort=field1[:direction],field2[:direction],...`
- `fieldN` is the JSON name of the field to sort by.
- `direction` can be 'asc' for ascending (default) or 'desc' for descending.

Key changes:
- Added `SortField` and `SortDirection` types in `resource/types.go`.
- Modified `resource/query_decoder.go`:
    - Added `parseSortParam` helper to parse and validate the 'sort' parameter.
    - `parseQuery` now uses this helper and populates `QuerySet.sortFields`.
- Modified `resource/queryset.go`:
    - Added `sortFields []SortField` and `SetSortFields` method to `QuerySet`.
    - Updated `SpannerStmt` and `PostgresStmt` to:
        - Construct and append an `ORDER BY` clause if sort fields are provided and no search is active.
        - Return a bad request error if 'sort' is used with search parameters.
    - Added `buildOrderByClause` helper to generate the SQL `ORDER BY` string.
- Added comprehensive unit tests in `resource/queryset_test.go` to cover:
    - Correct `ORDER BY` clause generation for Spanner and PostgreSQL.
    - Various sort field combinations and directions.
    - The error condition when 'sort' and search are used together.

All unit tests for the resource package pass with these changes.