### PR TITLE
Feature: Support generation of appropriate display type for Nullable booleans

### DIFF
--- a/resource/generation/types.go
+++ b/resource/generation/types.go
@@ -381,6 +381,10 @@ func (f resourceField) TypescriptDisplayType() string {
 		return "enumerated"
 	}
 
+	if f.typescriptType == "boolean" && f.IsNullable {
+		return "enumerated"
+	}
+
 	return f.typescriptType
 }
 


### PR DESCRIPTION
Solution:

If the field is a nullable boolean, we set the typescript type to enumerated instead
TODO: What would the enumerated values be?