### PR TITLE
feat: use `zz_gen` prefix for FE generated files

### DIFF
--- a/resource/generation/handler.go
+++ b/resource/generation/handler.go
@@ -88,7 +88,7 @@ func (r *resourceGenerator) generateHandlers(resource resourceInfo) error {
 
 	if len(handlerData) > 0 {
 		begin := time.Now()
-		fileName := generatedFileName(strings.ToLower(r.caser.ToSnake(r.pluralize(resource.Name()))))
+		fileName := generatedFileNameInGo(strings.ToLower(r.caser.ToSnake(r.pluralize(resource.Name()))))
 		destinationFilePath := filepath.Join(r.handlerDestination, fileName)
 
 		file, err := os.Create(destinationFilePath)
@@ -127,7 +127,7 @@ func (r *resourceGenerator) generateHandlers(resource resourceInfo) error {
 
 func (r *resourceGenerator) generateConsolidatedPatchHandler(resources []resourceInfo) error {
 	begin := time.Now()
-	fileName := generatedFileName(consolidatedHandlerOutputName)
+	fileName := generatedFileNameInGo(consolidatedHandlerOutputName)
 	destinationFilePath := filepath.Join(r.handlerDestination, fileName)
 
 	file, err := os.Create(destinationFilePath)

--- a/resource/generation/handler.go
+++ b/resource/generation/handler.go
@@ -88,7 +88,7 @@ func (r *resourceGenerator) generateHandlers(resource resourceInfo) error {
 
 	if len(handlerData) > 0 {
 		begin := time.Now()
-		fileName := generatedFileNameInGo(strings.ToLower(r.caser.ToSnake(r.pluralize(resource.Name()))))
+		fileName := generatedGoFileName(strings.ToLower(r.caser.ToSnake(r.pluralize(resource.Name()))))
 		destinationFilePath := filepath.Join(r.handlerDestination, fileName)
 
 		file, err := os.Create(destinationFilePath)
@@ -127,7 +127,7 @@ func (r *resourceGenerator) generateHandlers(resource resourceInfo) error {
 
 func (r *resourceGenerator) generateConsolidatedPatchHandler(resources []resourceInfo) error {
 	begin := time.Now()
-	fileName := generatedFileNameInGo(consolidatedHandlerOutputName)
+	fileName := generatedGoFileName(consolidatedHandlerOutputName)
 	destinationFilePath := filepath.Join(r.handlerDestination, fileName)
 
 	file, err := os.Create(destinationFilePath)

--- a/resource/generation/resource.go
+++ b/resource/generation/resource.go
@@ -143,7 +143,7 @@ func (r *resourceGenerator) generateResourceInterfaces() error {
 		return errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	destinationFile := filepath.Join(r.resourceDestination, generatedFileName(resourceInterfaceOutputName))
+	destinationFile := filepath.Join(r.resourceDestination, generatedFileNameInGo(resourceInterfaceOutputName))
 
 	file, err := os.Create(destinationFile)
 	if err != nil {
@@ -194,7 +194,7 @@ func (r *resourceGenerator) generateResourceTests() error {
 
 func (r *resourceGenerator) generateResources(res resourceInfo) error {
 	begin := time.Now()
-	fileName := generatedFileName(strings.ToLower(r.caser.ToSnake(r.pluralize(res.Name()))))
+	fileName := generatedFileNameInGo(strings.ToLower(r.caser.ToSnake(r.pluralize(res.Name()))))
 	destinationFilePath := filepath.Join(r.resourceDestination, fileName)
 
 	output, err := r.generateTemplateOutput("resourceFileTemplate", resourceFileTemplate, map[string]any{
@@ -240,7 +240,7 @@ func (r *resourceGenerator) generateEnums(namedTypes []*parser.NamedType) error 
 		return errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	file, err := os.Create(filepath.Join(r.resourceDestination, generatedFileName(resourceEnumsFileName)))
+	file, err := os.Create(filepath.Join(r.resourceDestination, generatedFileNameInGo(resourceEnumsFileName)))
 	if err != nil {
 		return errors.Wrap(err, "os.Create()")
 	}

--- a/resource/generation/resource.go
+++ b/resource/generation/resource.go
@@ -143,7 +143,7 @@ func (r *resourceGenerator) generateResourceInterfaces() error {
 		return errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	destinationFile := filepath.Join(r.resourceDestination, generatedFileNameInGo(resourceInterfaceOutputName))
+	destinationFile := filepath.Join(r.resourceDestination, generatedGoFileName(resourceInterfaceOutputName))
 
 	file, err := os.Create(destinationFile)
 	if err != nil {
@@ -194,7 +194,7 @@ func (r *resourceGenerator) generateResourceTests() error {
 
 func (r *resourceGenerator) generateResources(res resourceInfo) error {
 	begin := time.Now()
-	fileName := generatedFileNameInGo(strings.ToLower(r.caser.ToSnake(r.pluralize(res.Name()))))
+	fileName := generatedGoFileName(strings.ToLower(r.caser.ToSnake(r.pluralize(res.Name()))))
 	destinationFilePath := filepath.Join(r.resourceDestination, fileName)
 
 	output, err := r.generateTemplateOutput("resourceFileTemplate", resourceFileTemplate, map[string]any{
@@ -240,7 +240,7 @@ func (r *resourceGenerator) generateEnums(namedTypes []*parser.NamedType) error 
 		return errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	file, err := os.Create(filepath.Join(r.resourceDestination, generatedFileNameInGo(resourceEnumsFileName)))
+	file, err := os.Create(filepath.Join(r.resourceDestination, generatedGoFileName(resourceEnumsFileName)))
 	if err != nil {
 		return errors.Wrap(err, "os.Create()")
 	}

--- a/resource/generation/router.go
+++ b/resource/generation/router.go
@@ -54,13 +54,13 @@ func (r *resourceGenerator) runRouteGeneration() error {
 	}
 
 	if len(generatedRoutesMap) > 0 {
-		routesDestination := filepath.Join(r.routerDestination, generatedFileNameInGo(routesOutputName))
+		routesDestination := filepath.Join(r.routerDestination, generatedGoFileName(routesOutputName))
 		if err := r.writeGeneratedRouterFile(routesDestination, routesTemplate, r.resources, generatedRoutesMap); err != nil {
 			return errors.Wrap(err, "c.writeRoutes()")
 		}
 		log.Printf("Generated routes file in %s: %s\n", time.Since(begin), routesDestination)
 
-		routerTestsDestination := filepath.Join(r.routerDestination, generatedFileNameInGo(routerTestOutputName))
+		routerTestsDestination := filepath.Join(r.routerDestination, generatedGoFileName(routerTestOutputName))
 		begin = time.Now()
 		if err := r.writeGeneratedRouterFile(routerTestsDestination, routerTestTemplate, r.resources, generatedRoutesMap); err != nil {
 			return errors.Wrap(err, "c.writeRouterTests()")

--- a/resource/generation/router.go
+++ b/resource/generation/router.go
@@ -54,13 +54,13 @@ func (r *resourceGenerator) runRouteGeneration() error {
 	}
 
 	if len(generatedRoutesMap) > 0 {
-		routesDestination := filepath.Join(r.routerDestination, generatedFileName(routesOutputName))
+		routesDestination := filepath.Join(r.routerDestination, generatedFileNameInGo(routesOutputName))
 		if err := r.writeGeneratedRouterFile(routesDestination, routesTemplate, r.resources, generatedRoutesMap); err != nil {
 			return errors.Wrap(err, "c.writeRoutes()")
 		}
 		log.Printf("Generated routes file in %s: %s\n", time.Since(begin), routesDestination)
 
-		routerTestsDestination := filepath.Join(r.routerDestination, generatedFileName(routerTestOutputName))
+		routerTestsDestination := filepath.Join(r.routerDestination, generatedFileNameInGo(routerTestOutputName))
 		begin = time.Now()
 		if err := r.writeGeneratedRouterFile(routerTestsDestination, routerTestTemplate, r.resources, generatedRoutesMap); err != nil {
 			return errors.Wrap(err, "c.writeRouterTests()")

--- a/resource/generation/rpc.go
+++ b/resource/generation/rpc.go
@@ -64,7 +64,7 @@ func (r *resourceGenerator) runRPCGeneration() error {
 
 func (r *resourceGenerator) generateRPCHandler(rpcMethod rpcMethodInfo) error {
 	begin := time.Now()
-	fileName := generatedFileName(strings.ToLower(r.caser.ToSnake(rpcMethod.Name())))
+	fileName := generatedFileNameInGo(strings.ToLower(r.caser.ToSnake(rpcMethod.Name())))
 	destinationFilePath := filepath.Join(r.handlerDestination, fileName)
 
 	file, err := os.Create(destinationFilePath)
@@ -102,7 +102,7 @@ func (r *resourceGenerator) generateRPCHandler(rpcMethod rpcMethodInfo) error {
 }
 
 func (r *resourceGenerator) generateRPCMethod(rpcMethod rpcMethodInfo) error {
-	fileName := generatedFileName(strings.ToLower(r.caser.ToSnake(rpcMethod.Name())))
+	fileName := generatedFileNameInGo(strings.ToLower(r.caser.ToSnake(rpcMethod.Name())))
 	destinationFilePath := filepath.Join(r.businessLayerPackageDir, fileName)
 
 	file, err := os.Create(destinationFilePath)
@@ -149,7 +149,7 @@ func (r *resourceGenerator) generateRPCInterfaces() error {
 		return errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	destinationFile := filepath.Join("./businesslayer/rpc", generatedFileName("rpc_iface"))
+	destinationFile := filepath.Join("./businesslayer/rpc", generatedFileNameInGo("rpc_iface"))
 
 	file, err := os.Create(destinationFile)
 	if err != nil {
@@ -179,7 +179,7 @@ func (r *resourceGenerator) generateBusinessLayerInterfaces() error {
 		return errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	destinationFile := filepath.Join("./businesslayer", generatedFileName("iface"))
+	destinationFile := filepath.Join("./businesslayer", generatedFileNameInGo("iface"))
 
 	file, err := os.Create(destinationFile)
 	if err != nil {

--- a/resource/generation/rpc.go
+++ b/resource/generation/rpc.go
@@ -64,7 +64,7 @@ func (r *resourceGenerator) runRPCGeneration() error {
 
 func (r *resourceGenerator) generateRPCHandler(rpcMethod rpcMethodInfo) error {
 	begin := time.Now()
-	fileName := generatedFileNameInGo(strings.ToLower(r.caser.ToSnake(rpcMethod.Name())))
+	fileName := generatedGoFileName(strings.ToLower(r.caser.ToSnake(rpcMethod.Name())))
 	destinationFilePath := filepath.Join(r.handlerDestination, fileName)
 
 	file, err := os.Create(destinationFilePath)
@@ -102,7 +102,7 @@ func (r *resourceGenerator) generateRPCHandler(rpcMethod rpcMethodInfo) error {
 }
 
 func (r *resourceGenerator) generateRPCMethod(rpcMethod rpcMethodInfo) error {
-	fileName := generatedFileNameInGo(strings.ToLower(r.caser.ToSnake(rpcMethod.Name())))
+	fileName := generatedGoFileName(strings.ToLower(r.caser.ToSnake(rpcMethod.Name())))
 	destinationFilePath := filepath.Join(r.businessLayerPackageDir, fileName)
 
 	file, err := os.Create(destinationFilePath)
@@ -149,7 +149,7 @@ func (r *resourceGenerator) generateRPCInterfaces() error {
 		return errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	destinationFile := filepath.Join("./businesslayer/rpc", generatedFileNameInGo("rpc_iface"))
+	destinationFile := filepath.Join("./businesslayer/rpc", generatedGoFileName("rpc_iface"))
 
 	file, err := os.Create(destinationFile)
 	if err != nil {
@@ -179,7 +179,7 @@ func (r *resourceGenerator) generateBusinessLayerInterfaces() error {
 		return errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	destinationFile := filepath.Join("./businesslayer", generatedFileNameInGo("iface"))
+	destinationFile := filepath.Join("./businesslayer", generatedGoFileName("iface"))
 
 	file, err := os.Create(destinationFile)
 	if err != nil {

--- a/resource/generation/types.go
+++ b/resource/generation/types.go
@@ -632,11 +632,11 @@ func (s searchExpression) String() string {
 	return fmt.Sprintf("TOKENIZE_%s(%s)", strings.ToUpper(string(s.TokenType)), s.Argument)
 }
 
-func generatedFileNameInGo(name string) string {
+func generatedGoFileName(name string) string {
 	return generatedFileName(name, "go")
 }
 
-func generatedFileNameInTypescript(name string) string {
+func generatedTypescriptFileName(name string) string {
 	return generatedFileName(name, "ts")
 }
 

--- a/resource/generation/types.go
+++ b/resource/generation/types.go
@@ -632,8 +632,16 @@ func (s searchExpression) String() string {
 	return fmt.Sprintf("TOKENIZE_%s(%s)", strings.ToUpper(string(s.TokenType)), s.Argument)
 }
 
-func generatedFileName(name string) string {
-	return fmt.Sprintf("%s_%s.go", genPrefix, name)
+func generatedFileNameInGo(name string) string {
+	return generatedFileName(name, "go")
+}
+
+func generatedFileNameInTypescript(name string) string {
+	return generatedFileName(name, "ts")
+}
+
+func generatedFileName(name string, suffix string) string {
+	return fmt.Sprintf("%s_%s.%s", genPrefix, name, suffix)
 }
 
 const (

--- a/resource/generation/typescript.go
+++ b/resource/generation/typescript.go
@@ -162,7 +162,7 @@ func (t *typescriptGenerator) runTypescriptPermissionGeneration() error {
 		return errors.Wrap(err, "c.generateTemplateOutput()")
 	}
 
-	destinationFilePath := filepath.Join(t.typescriptDestination, "zz_gen_constants.ts")
+	destinationFilePath := filepath.Join(t.typescriptDestination, generatedFileNameInTypescript("constants"))
 	file, err := os.Create(destinationFilePath)
 	if err != nil {
 		return errors.Wrap(err, "os.Create()")
@@ -218,7 +218,7 @@ func (t *typescriptGenerator) generateResourceMetadata() error {
 		return errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	destinationFilePath := filepath.Join(t.typescriptDestination, "zz_gen_resources.ts")
+	destinationFilePath := filepath.Join(t.typescriptDestination, generatedFileNameInTypescript("resources"))
 	file, err := os.Create(destinationFilePath)
 	if err != nil {
 		return errors.Wrap(err, "os.Create()")
@@ -245,7 +245,7 @@ func (t *typescriptGenerator) generateMethodMetadata() error {
 		return errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	destinationFilePath := filepath.Join(t.typescriptDestination, "zz_gen_methods.ts")
+	destinationFilePath := filepath.Join(t.typescriptDestination, generatedFileNameInTypescript("methods"))
 	file, err := os.Create(destinationFilePath)
 	if err != nil {
 		return errors.Wrap(err, "os.Create()")
@@ -279,7 +279,7 @@ func (t *typescriptGenerator) generateEnums(namedTypes []*parser.NamedType) erro
 		return errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	file, err := os.Create(filepath.Join(t.typescriptDestination, "enums.ts"))
+	file, err := os.Create(filepath.Join(t.typescriptDestination, generatedFileNameInTypescript("enums")))
 	if err != nil {
 		return errors.Wrap(err, "os.Create()")
 	}

--- a/resource/generation/typescript.go
+++ b/resource/generation/typescript.go
@@ -162,7 +162,7 @@ func (t *typescriptGenerator) runTypescriptPermissionGeneration() error {
 		return errors.Wrap(err, "c.generateTemplateOutput()")
 	}
 
-	destinationFilePath := filepath.Join(t.typescriptDestination, "constants.ts")
+	destinationFilePath := filepath.Join(t.typescriptDestination, "zz_gen_constants.ts")
 	file, err := os.Create(destinationFilePath)
 	if err != nil {
 		return errors.Wrap(err, "os.Create()")
@@ -218,7 +218,7 @@ func (t *typescriptGenerator) generateResourceMetadata() error {
 		return errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	destinationFilePath := filepath.Join(t.typescriptDestination, "resources.ts")
+	destinationFilePath := filepath.Join(t.typescriptDestination, "zz_gen_resources.ts")
 	file, err := os.Create(destinationFilePath)
 	if err != nil {
 		return errors.Wrap(err, "os.Create()")
@@ -245,7 +245,7 @@ func (t *typescriptGenerator) generateMethodMetadata() error {
 		return errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	destinationFilePath := filepath.Join(t.typescriptDestination, "methods.ts")
+	destinationFilePath := filepath.Join(t.typescriptDestination, "zz_gen_methods.ts")
 	file, err := os.Create(destinationFilePath)
 	if err != nil {
 		return errors.Wrap(err, "os.Create()")

--- a/resource/generation/typescript.go
+++ b/resource/generation/typescript.go
@@ -162,7 +162,7 @@ func (t *typescriptGenerator) runTypescriptPermissionGeneration() error {
 		return errors.Wrap(err, "c.generateTemplateOutput()")
 	}
 
-	destinationFilePath := filepath.Join(t.typescriptDestination, generatedFileNameInTypescript("constants"))
+	destinationFilePath := filepath.Join(t.typescriptDestination, generatedTypescriptFileName("constants"))
 	file, err := os.Create(destinationFilePath)
 	if err != nil {
 		return errors.Wrap(err, "os.Create()")
@@ -218,7 +218,7 @@ func (t *typescriptGenerator) generateResourceMetadata() error {
 		return errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	destinationFilePath := filepath.Join(t.typescriptDestination, generatedFileNameInTypescript("resources"))
+	destinationFilePath := filepath.Join(t.typescriptDestination, generatedTypescriptFileName("resources"))
 	file, err := os.Create(destinationFilePath)
 	if err != nil {
 		return errors.Wrap(err, "os.Create()")
@@ -245,7 +245,7 @@ func (t *typescriptGenerator) generateMethodMetadata() error {
 		return errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	destinationFilePath := filepath.Join(t.typescriptDestination, generatedFileNameInTypescript("methods"))
+	destinationFilePath := filepath.Join(t.typescriptDestination, generatedTypescriptFileName("methods"))
 	file, err := os.Create(destinationFilePath)
 	if err != nil {
 		return errors.Wrap(err, "os.Create()")
@@ -279,7 +279,7 @@ func (t *typescriptGenerator) generateEnums(namedTypes []*parser.NamedType) erro
 		return errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	file, err := os.Create(filepath.Join(t.typescriptDestination, generatedFileNameInTypescript("enums")))
+	file, err := os.Create(filepath.Join(t.typescriptDestination, generatedTypescriptFileName("enums")))
 	if err != nil {
 		return errors.Wrap(err, "os.Create()")
 	}


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat!: use zz_gen prefix for TypeScript generated files (#434)

feat!: Old generated TypeScript files will need all Angular imports updated to the new filename `(constants.ts, resources.ts, methods.ts, and enums.ts)` (#434)
END_COMMIT_OVERRIDE

Currently, `methods.ts`, `resources.ts`, `constants.ts`, and `enums.ts` are all generated files, but they lack the `zz_gen_` prefix to denote that. This PR adds that prefix to those four generated files. The PR has been successfully tested in this draft PR: https://github.com/AscendiumApps/ga-lite-app/pull/1369. That draft PR was created by running the following two commands in order:
1. `go get github.com/cccteam/ccc/resource@SHA`
2. `go generate ./...`