### PR TITLE
feat: Support resource-level defaults for create & update

### DIFF
--- a/resource/generation/extract.go
+++ b/resource/generation/extract.go
@@ -55,6 +55,22 @@ func (c *client) extractResources(structs []*parser.Struct) ([]resourceInfo, err
 			}
 		}
 
+		if result.Struct.Has(defaultsCreateFuncKeyword) {
+			args := result.Struct.Get(defaultsCreateFuncKeyword)
+			if len(args) != 1 {
+				return nil, errors.Newf("@%s should have exactly one argument, found %d on %s", defaultsCreateFuncKeyword, len(args), resourceName)
+			}
+			resource.DefaultsCreateFunc = args[0].Arg1
+		}
+
+		if result.Struct.Has(defaultsUpdateFuncKeyword) {
+			args := result.Struct.Get(defaultsUpdateFuncKeyword)
+			if len(args) != 1 {
+				return nil, errors.Newf("@%s should have exactly one argument, found %d on %s", defaultsUpdateFuncKeyword, len(args), resourceName)
+			}
+			resource.DefaultsUpdateFunc = args[0].Arg1
+		}
+
 		for i, field := range pStruct.Fields() {
 			spannerTag, ok := field.LookupTag("spanner")
 			if !ok {

--- a/resource/generation/parser/genlang/scanner.go
+++ b/resource/generation/parser/genlang/scanner.go
@@ -19,6 +19,7 @@ type (
 		keywordArguments map[string][]Args
 		keywords         map[string]KeywordOpts
 		pos              int
+		maxKeywordLength int
 	}
 
 	StructResults struct {
@@ -38,9 +39,17 @@ const (
 )
 
 func NewScanner(keywords map[string]KeywordOpts) Scanner {
+	maxKeywordLength := 0
+	for k := range keywords {
+		if l := len(k); l > maxKeywordLength {
+			maxKeywordLength = l
+		}
+	}
+
 	return &scanner{
 		keywordArguments: make(map[string][]Args),
 		keywords:         keywords,
+		maxKeywordLength: maxKeywordLength,
 	}
 }
 
@@ -304,8 +313,7 @@ func (s *scanner) consumeIdentifier() []byte {
 	buf := make([]byte, 0)
 	for {
 		char, eof := s.next()
-		// If buffer is longer than any known identifier we should return
-		if isWhitespace(char) || len(buf) > 12 || eof {
+		if isWhitespace(char) || len(buf) > s.maxKeywordLength || eof {
 			break
 		}
 

--- a/resource/generation/templates.go
+++ b/resource/generation/templates.go
@@ -344,6 +344,9 @@ func (p *{{ .Resource.Name }}CreatePatch) registerDefaultFuncs() {
 	p.patchSet.RegisterDefaultCreateFunc("{{ $field.Name }}", {{ $field.DefaultCreateFuncName }})
 {{- end }}
 {{- end }}
+{{- if .Resource.HasDefaultsCreateFunc }}
+	p.patchSet.RegisterDefaultsCreateFunc({{ .Resource.DefaultsCreateFunc }})
+{{- end }}
 }
 
 ` + fieldAccessors(CreatePatch) + `
@@ -403,6 +406,9 @@ func (p *{{ .Resource.Name }}UpdatePatch) registerDefaultFuncs() {
 {{- if $field.HasDefaultUpdateFunc }}
 	p.patchSet.RegisterDefaultUpdateFunc("{{ $field.Name }}", {{ $field.DefaultUpdateFuncName }})
 {{- end }}
+{{- end }}
+{{- if .Resource.HasDefaultsUpdateFunc }}
+	p.patchSet.RegisterDefaultsUpdateFunc({{ .Resource.DefaultsUpdateFunc }})
 {{- end }}
 }
 

--- a/resource/generation/templates.go
+++ b/resource/generation/templates.go
@@ -345,7 +345,9 @@ func (p *{{ .Resource.Name }}CreatePatch) registerDefaultFuncs() {
 {{- end }}
 {{- end }}
 {{- if .Resource.HasDefaultsCreateFunc }}
-	p.patchSet.RegisterDefaultsCreateFunc({{ .Resource.DefaultsCreateFunc }})
+	p.patchSet.RegisterDefaultsCreateFunc(func(ctx context.Context, txn resource.TxnBuffer) error {
+		return {{ .Resource.DefaultsCreateFunc }}(ctx, txn, p)
+	})
 {{- end }}
 }
 
@@ -408,7 +410,9 @@ func (p *{{ .Resource.Name }}UpdatePatch) registerDefaultFuncs() {
 {{- end }}
 {{- end }}
 {{- if .Resource.HasDefaultsUpdateFunc }}
-	p.patchSet.RegisterDefaultsUpdateFunc({{ .Resource.DefaultsUpdateFunc }})
+	p.patchSet.RegisterDefaultsUpdateFunc(func(ctx context.Context, txn resource.TxnBuffer) error {
+		return {{ .Resource.DefaultsUpdateFunc }}(ctx, txn, p)
+	})
 {{- end }}
 }
 

--- a/resource/generation/types.go
+++ b/resource/generation/types.go
@@ -223,10 +223,12 @@ func (r resourceInfo) DeleteHandlerDisabled() bool {
 	return slices.Contains(r.SuppressedHandlers[:], PatchHandler)
 }
 
+// HasDefaultsCreateFunc indicates if a default create function has been registered
 func (r resourceInfo) HasDefaultsCreateFunc() bool {
 	return r.DefaultsCreateFunc != ""
 }
 
+// HasDefaultsUpdateFunc indicates if a default update function has been registered
 func (r resourceInfo) HasDefaultsUpdateFunc() bool {
 	return r.DefaultsUpdateFunc != ""
 }

--- a/resource/generation/types.go
+++ b/resource/generation/types.go
@@ -199,6 +199,8 @@ type resourceInfo struct {
 	IsView             bool                           // Determines how CreatePatch is rendered in resource generation.
 	IsConsolidated     bool
 	PkCount            int
+	DefaultsCreateFunc string
+	DefaultsUpdateFunc string
 }
 
 func (r resourceInfo) ListHandlerDisabled() bool {
@@ -219,6 +221,14 @@ func (r resourceInfo) UpdateHandlerDisabled() bool {
 
 func (r resourceInfo) DeleteHandlerDisabled() bool {
 	return slices.Contains(r.SuppressedHandlers[:], PatchHandler)
+}
+
+func (r resourceInfo) HasDefaultsCreateFunc() bool {
+	return r.DefaultsCreateFunc != ""
+}
+
+func (r resourceInfo) HasDefaultsUpdateFunc() bool {
+	return r.DefaultsUpdateFunc != ""
 }
 
 func (r resourceInfo) SearchIndexes() []searchIndex {
@@ -645,13 +655,17 @@ func generatedFileName(name string, suffix string) string {
 }
 
 const (
-	enumerateKeyword string = "enumerate" // Generate constants based on existing values in Spanner DB (from inserts in migrations directory)
-	suppressKeyword  string = "suppress"  // Suppresses specified handler types from being generated
+	enumerateKeyword          string = "enumerate"        // Generate constants based on existing values in Spanner DB (from inserts in migrations directory)
+	suppressKeyword           string = "suppress"         // Suppresses specified handler types from being generated
+	defaultsCreateFuncKeyword string = "defaultsCreateFn" // Specifies a function to call for setting defaults on resource creation
+	defaultsUpdateFuncKeyword string = "defaultsUpdateFn" // Specifies a function to call for setting defaults on resource update
 )
 
 func keywords() map[string]genlang.KeywordOpts {
 	return map[string]genlang.KeywordOpts{
-		enumerateKeyword: {genlang.ScanNamedType: genlang.ArgsRequired | genlang.Exclusive},
-		suppressKeyword:  {genlang.ScanStruct: genlang.ArgsRequired},
+		enumerateKeyword:          {genlang.ScanNamedType: genlang.ArgsRequired | genlang.Exclusive},
+		suppressKeyword:           {genlang.ScanStruct: genlang.ArgsRequired},
+		defaultsCreateFuncKeyword: {genlang.ScanStruct: genlang.ArgsRequired},
+		defaultsUpdateFuncKeyword: {genlang.ScanStruct: genlang.ArgsRequired},
 	}
 }

--- a/resource/patchset.go
+++ b/resource/patchset.go
@@ -637,10 +637,14 @@ func (p *PatchSet[Resource]) RegisterDefaultUpdateFunc(field accesstypes.Field, 
 	p.defaultUpdateFuncs[field] = fn
 }
 
+// RegisterDefaultsCreateFunc registers a function that will be called on all
+// Create Patches just before the patch is buffered
 func (p *PatchSet[Resource]) RegisterDefaultsCreateFunc(fn DefaultsFunc) {
 	p.defaultsCreateFunc = fn
 }
 
+// RegisterDefaultsUpdateFunc registers a function that will be called on all
+// Update Patches just before the patch is buffered
 func (p *PatchSet[Resource]) RegisterDefaultsUpdateFunc(fn DefaultsFunc) {
 	p.defaultsUpdateFunc = fn
 }

--- a/resource/patchset.go
+++ b/resource/patchset.go
@@ -31,8 +31,8 @@ type PatchSet[Resource Resourcer] struct {
 	patchType          PatchType
 	defaultCreateFuncs map[accesstypes.Field]FieldDefaultFunc
 	defaultUpdateFuncs map[accesstypes.Field]FieldDefaultFunc
-	defaultsCreateFunc defaultsFunc
-	defaultsUpdateFunc defaultsFunc
+	defaultsCreateFunc DefaultsFunc
+	defaultsUpdateFunc DefaultsFunc
 }
 
 func NewPatchSet[Resource Resourcer](rMeta *ResourceMetadata[Resource]) *PatchSet[Resource] {
@@ -637,11 +637,11 @@ func (p *PatchSet[Resource]) RegisterDefaultUpdateFunc(field accesstypes.Field, 
 	p.defaultUpdateFuncs[field] = fn
 }
 
-func (p *PatchSet[Resource]) RegisterDefaultsCreateFunc(fn defaultsFunc) {
+func (p *PatchSet[Resource]) RegisterDefaultsCreateFunc(fn DefaultsFunc) {
 	p.defaultsCreateFunc = fn
 }
 
-func (p *PatchSet[Resource]) RegisterDefaultsUpdateFunc(fn defaultsFunc) {
+func (p *PatchSet[Resource]) RegisterDefaultsUpdateFunc(fn DefaultsFunc) {
 	p.defaultsUpdateFunc = fn
 }
 

--- a/resource/patchset.go
+++ b/resource/patchset.go
@@ -213,12 +213,6 @@ func (p *PatchSet[Resource]) spannerBufferInsert(ctx context.Context, txn TxnBuf
 		return err
 	}
 
-	if p.defaultsCreateFunc != nil {
-		if err := p.defaultsCreateFunc(ctx, txn); err != nil {
-			return errors.Wrap(err, "defaultsCreateFunc()")
-		}
-	}
-
 	for field, defaultFunc := range p.defaultCreateFuncs {
 		if !p.IsSet(field) {
 			d, err := defaultFunc(ctx, txn)
@@ -226,6 +220,12 @@ func (p *PatchSet[Resource]) spannerBufferInsert(ctx context.Context, txn TxnBuf
 				return errors.Wrap(err, "defaultFunc()")
 			}
 			p.Set(field, d)
+		}
+	}
+
+	if p.defaultsCreateFunc != nil {
+		if err := p.defaultsCreateFunc(ctx, txn); err != nil {
+			return errors.Wrap(err, "defaultsCreateFunc()")
 		}
 	}
 
@@ -258,12 +258,6 @@ func (p *PatchSet[Resource]) spannerBufferUpdate(ctx context.Context, txn TxnBuf
 		return err
 	}
 
-	if p.defaultsUpdateFunc != nil {
-		if err := p.defaultsUpdateFunc(ctx, txn); err != nil {
-			return errors.Wrap(err, "defaultsUpdateFunc()")
-		}
-	}
-
 	for field, defaultFunc := range p.defaultUpdateFuncs {
 		if !p.IsSet(field) {
 			d, err := defaultFunc(ctx, txn)
@@ -271,6 +265,12 @@ func (p *PatchSet[Resource]) spannerBufferUpdate(ctx context.Context, txn TxnBuf
 				return errors.Wrap(err, "defaultFunc()")
 			}
 			p.Set(field, d)
+		}
+	}
+
+	if p.defaultsUpdateFunc != nil {
+		if err := p.defaultsUpdateFunc(ctx, txn); err != nil {
+			return errors.Wrap(err, "defaultsUpdateFunc()")
 		}
 	}
 

--- a/resource/patchset.go
+++ b/resource/patchset.go
@@ -31,8 +31,8 @@ type PatchSet[Resource Resourcer] struct {
 	patchType          PatchType
 	defaultCreateFuncs map[accesstypes.Field]FieldDefaultFunc
 	defaultUpdateFuncs map[accesstypes.Field]FieldDefaultFunc
-	defaultsCreateFunc DefaultsFunc[Resource]
-	defaultsUpdateFunc DefaultsFunc[Resource]
+	defaultsCreateFunc defaultsFunc
+	defaultsUpdateFunc defaultsFunc
 }
 
 func NewPatchSet[Resource Resourcer](rMeta *ResourceMetadata[Resource]) *PatchSet[Resource] {
@@ -214,7 +214,7 @@ func (p *PatchSet[Resource]) spannerBufferInsert(ctx context.Context, txn TxnBuf
 	}
 
 	if p.defaultsCreateFunc != nil {
-		if err := p.defaultsCreateFunc(ctx, txn, p); err != nil {
+		if err := p.defaultsCreateFunc(ctx, txn); err != nil {
 			return errors.Wrap(err, "defaultsCreateFunc()")
 		}
 	}
@@ -259,7 +259,7 @@ func (p *PatchSet[Resource]) spannerBufferUpdate(ctx context.Context, txn TxnBuf
 	}
 
 	if p.defaultsUpdateFunc != nil {
-		if err := p.defaultsUpdateFunc(ctx, txn, p); err != nil {
+		if err := p.defaultsUpdateFunc(ctx, txn); err != nil {
 			return errors.Wrap(err, "defaultsUpdateFunc()")
 		}
 	}
@@ -637,11 +637,11 @@ func (p *PatchSet[Resource]) RegisterDefaultUpdateFunc(field accesstypes.Field, 
 	p.defaultUpdateFuncs[field] = fn
 }
 
-func (p *PatchSet[Resource]) RegisterDefaultsCreateFunc(fn DefaultsFunc[Resource]) {
+func (p *PatchSet[Resource]) RegisterDefaultsCreateFunc(fn defaultsFunc) {
 	p.defaultsCreateFunc = fn
 }
 
-func (p *PatchSet[Resource]) RegisterDefaultsUpdateFunc(fn DefaultsFunc[Resource]) {
+func (p *PatchSet[Resource]) RegisterDefaultsUpdateFunc(fn defaultsFunc) {
 	p.defaultsUpdateFunc = fn
 }
 

--- a/resource/resourceset.go
+++ b/resource/resourceset.go
@@ -17,10 +17,6 @@ import (
 type (
 	FieldDefaultFunc func(ctx context.Context, txn TxnBuffer) (any, error)
 	defaultsFunc     func(ctx context.Context, txn TxnBuffer) error
-
-	// Required signature for user-defined functions that handle settting resource default values (on update or create).
-	// The patch parameter should be the resource-specific patch type (e.g. *UserCreatePatch or *UserUpdatePatch for a "User" resource).
-	DefaultsFunc func(ctx context.Context, txn TxnBuffer, patch any) error
 )
 
 type Resourcer interface {

--- a/resource/resourceset.go
+++ b/resource/resourceset.go
@@ -16,7 +16,7 @@ import (
 
 type (
 	FieldDefaultFunc func(ctx context.Context, txn TxnBuffer) (any, error)
-	defaultsFunc     func(ctx context.Context, txn TxnBuffer) error
+	DefaultsFunc     func(ctx context.Context, txn TxnBuffer) error
 )
 
 type Resourcer interface {

--- a/resource/resourceset.go
+++ b/resource/resourceset.go
@@ -15,8 +15,11 @@ import (
 )
 
 type (
+	// FieldDefaultFunc is the signature for a function that applies a default value to one field of a PatchSet.
 	FieldDefaultFunc func(ctx context.Context, txn TxnBuffer) (any, error)
-	DefaultsFunc     func(ctx context.Context, txn TxnBuffer) error
+
+	// DefaultsFunc is the signature for a function that applies default values to a PatchSet.
+	DefaultsFunc func(ctx context.Context, txn TxnBuffer) error
 )
 
 type Resourcer interface {

--- a/resource/resourceset.go
+++ b/resource/resourceset.go
@@ -15,8 +15,9 @@ import (
 )
 
 type (
-	FieldDefaultFunc                 func(ctx context.Context, txn TxnBuffer) (any, error)
-	DefaultsFunc[Resource Resourcer] func(ctx context.Context, txn TxnBuffer, patch *PatchSet[Resource]) error
+	FieldDefaultFunc func(ctx context.Context, txn TxnBuffer) (any, error)
+	DefaultsFunc     func(ctx context.Context, txn TxnBuffer, patch any) error
+	defaultsFunc     func(ctx context.Context, txn TxnBuffer) error
 )
 
 type Resourcer interface {

--- a/resource/resourceset.go
+++ b/resource/resourceset.go
@@ -14,7 +14,10 @@ import (
 	"github.com/go-playground/errors/v5"
 )
 
-type FieldDefaultFunc func(ctx context.Context, txn TxnBuffer) (any, error)
+type (
+	FieldDefaultFunc                 func(ctx context.Context, txn TxnBuffer) (any, error)
+	DefaultsFunc[Resource Resourcer] func(ctx context.Context, txn TxnBuffer, patch *PatchSet[Resource]) error
+)
 
 type Resourcer interface {
 	Resource() accesstypes.Resource

--- a/resource/resourceset.go
+++ b/resource/resourceset.go
@@ -16,8 +16,11 @@ import (
 
 type (
 	FieldDefaultFunc func(ctx context.Context, txn TxnBuffer) (any, error)
-	DefaultsFunc     func(ctx context.Context, txn TxnBuffer, patch any) error
 	defaultsFunc     func(ctx context.Context, txn TxnBuffer) error
+
+	// Required signature for user-defined functions that handle settting resource default values (on update or create).
+	// The patch parameter should be the resource-specific patch type (e.g. *UserCreatePatch or *UserUpdatePatch for a "User" resource).
+	DefaultsFunc func(ctx context.Context, txn TxnBuffer, patch any) error
 )
 
 type Resourcer interface {


### PR DESCRIPTION
closes #291 

@jwatson-ccc 
I realize that your initial idea was to have the generator automatically find these create default funcs & update default funcs based on their signature. However, I liked the consistency and explicitness provided by following the resource tagging system.  This way, the developer is able to see all defined default functions (resource level and field level) by simply examining the resource's definition. Please let me know if you disagree and we can discuss this further. Thanks!