### PR TITLE
feature: Switch to cbor to allow larger cache sizes

### DIFF
--- a/cache/.golangci.yml
+++ b/cache/.golangci.yml
@@ -60,8 +60,9 @@ linters:
             - $all
           allow:
             - github.com/cccteam/ccc/cache
-            - github.com/google/go-cmp/cmp
+            - github.com/fxamacker/cbor/v2
             - github.com/go-playground/errors/v5
+            - github.com/google/go-cmp/cmp
             - $gostd
     dupl:
       threshold: 100

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -4,7 +4,6 @@
 package cache
 
 import (
-	"encoding/gob"
 	"io/fs"
 	"iter"
 	"os"
@@ -12,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/fxamacker/cbor/v2"
 	"github.com/go-playground/errors/v5"
 )
 
@@ -38,6 +38,7 @@ type Cache struct {
 	mu             sync.RWMutex
 	cacheFolder    string
 	root           *os.Root
+	decoderOpts    cbor.DecOptions
 }
 
 // New creates a new Cache, with its storage located at `path“ concatenated with `.ccc-cache/`.
@@ -46,6 +47,7 @@ func New(path string, opts ...Option) (*Cache, error) {
 	c := &Cache{
 		permissionBits: 0o755,
 		cacheFolder:    filepath.Join(path, cachePrefix),
+		decoderOpts:    cbor.DecOptions{MaxMapPairs: 2147483647},
 	}
 
 	for _, opt := range opts {
@@ -112,9 +114,14 @@ func (c *Cache) Load(subpath, key string, dst any) (bool, error) {
 	}
 	defer f.Close()
 
-	decoder := gob.NewDecoder(f)
+	decOpts, err := c.decoderOpts.DecMode()
+	if err != nil {
+		return false, errors.Wrap(err, "cbor.DecOptions.DecMode()")
+	}
+
+	decoder := decOpts.NewDecoder(f)
 	if err := decoder.Decode(dst); err != nil {
-		return false, errors.Wrap(err, "gob.Decoder.Decode()")
+		return false, errors.Wrap(err, "cbor.Decoder.Decode()")
 	}
 
 	return true, nil
@@ -190,9 +197,9 @@ func (c *Cache) Store(subpath, key string, data any) error {
 		return errors.Wrap(err, "os.Root.OpenFile()")
 	}
 
-	encoder := gob.NewEncoder(f)
+	encoder := cbor.NewEncoder(f)
 	if err := encoder.Encode(data); err != nil {
-		return errors.Wrap(err, "gob.Encoder.Encode()")
+		return errors.Wrap(err, "cbor.Encoder.Encode()")
 	}
 	if err := f.Close(); err != nil {
 		return errors.Wrap(err, "os.File.Close()")

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -192,6 +192,12 @@ func (c *Cache) Store(subpath, key string, data any) error {
 	}
 
 	fileName := filepath.Join(subpath, key)
+	if err := c.root.Remove(fileName); err != nil {
+		if !os.IsNotExist(err) {
+			return errors.Wrap(err, "os.Root.Remove()")
+		}
+	}
+
 	f, err := c.root.OpenFile(fileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_SYNC, fs.FileMode(c.permissionBits))
 	if err != nil {
 		return errors.Wrap(err, "os.Root.OpenFile()")

--- a/cache/go.mod
+++ b/cache/go.mod
@@ -3,8 +3,12 @@ module github.com/cccteam/ccc/cache
 go 1.25.0
 
 require (
+	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/go-playground/errors/v5 v5.4.0
 	github.com/google/go-cmp v0.7.0
 )
 
-require github.com/go-playground/pkg/v5 v5.21.3 // indirect
+require (
+	github.com/go-playground/pkg/v5 v5.21.3 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
+)

--- a/cache/go.sum
+++ b/cache/go.sum
@@ -1,6 +1,10 @@
+github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
+github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-playground/errors/v5 v5.4.0 h1:BxBxwlRjuclYbRebE4ddrRrMK705lS2mHzHw7BDoDPA=
 github.com/go-playground/errors/v5 v5.4.0/go.mod h1:6aVeVHsT36RNu/m/8AvGdPv8T2J/+KfVv6Su4VvBfpQ=
 github.com/go-playground/pkg/v5 v5.21.3 h1:1IVy0eupI5kht6L6zaAqTEvjs00zLkG28ictNkoN1wE=
 github.com/go-playground/pkg/v5 v5.21.3/go.mod h1:UgHNntEQnMJSygw2O2RQ3LAB0tprx81K90c/pOKh7cU=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=


### PR DESCRIPTION
BEGIN_OVERRIDE_COMMIT
feature: Switch to cbor to allow larger cache sizes (#447)

feature!: Switch to cbor will require you to delete the existing cache because cbor can not read gob encoding (#447)

fix: Remove cache object instead of overwriting to avoid permission issues (#447)
END_OVERRIDE_COMMIT