### PR TITLE
feature: exclude resource from typescript generator with notypescript keyword

### DIFF
--- a/resource/generation/extract.go
+++ b/resource/generation/extract.go
@@ -88,6 +88,10 @@ func (c *client) extractResources(structs []*parser.Struct) ([]*resourceInfo, er
 			resource.ValidateUpdateType = result.Struct.GetOne(validateUpdateTypeKeyword).Arg1
 		}
 
+		if result.Struct.Has(noTypescriptKeyword) {
+			resource.noTypescript = true
+		}
+
 		resources = append(resources, resource)
 	}
 

--- a/resource/generation/templates.go
+++ b/resource/generation/templates.go
@@ -893,7 +893,9 @@ export const Domains = {
 
 export const Resources = {
 {{- range $resource := $resources }}
+  {{- if not (index $.ExcludedResources $resource) }}
   {{ $resource }}: '{{ $resource }}' as Resource,
+  {{- end }}
 {{- end}}
 };
 
@@ -904,6 +906,7 @@ export const Methods = {
 };
 
 {{ range $resource, $tags := $resourcetags }}
+{{- if not (index $.ExcludedResources $resource) }}
 export namespace {{ $resource }} {
   export const fieldName = {
   {{- range $_, $tag := $tags }}
@@ -916,6 +919,7 @@ export namespace {{ $resource }} {
   {{- end }}
   };
 };
+{{- end }}
 {{ end }}
 {{ range $rpcMethod := $rpcMethods }}
 export namespace {{ $rpcMethod.Name }} {
@@ -931,6 +935,7 @@ type PermissionMappings = Record<Resource, ResourcePermissions>;
 
 const Mappings: PermissionMappings = {
   {{- range $resource := $resources }}
+  {{- if not (index $.ExcludedResources $resource) }}
   [Resources.{{ $resource }}]: {
     {{- range $perm := $resourcePermissions }}
     [Permissions.{{ $perm }}]: {{ index $resourcePermMap $resource $perm }},
@@ -943,6 +948,7 @@ const Mappings: PermissionMappings = {
       {{- end }}
   },
     {{- end }}
+  {{- end }}
   {{- end }}
 };
 

--- a/resource/generation/types.go
+++ b/resource/generation/types.go
@@ -241,6 +241,7 @@ type resourceInfo struct {
 	DefaultsUpdateType string
 	ValidateCreateType string
 	ValidateUpdateType string
+	noTypescript       bool
 }
 
 func (r *resourceInfo) ListHandlerDisabled() bool {
@@ -734,6 +735,7 @@ const (
 	defaultsUpdateTypeKeyword string = "defaultsUpdateType" // Specifies a type to call "Defaults()" on for setting defaults on resource update
 	validateCreateTypeKeyword string = "validateCreateType" // Specifies a type to call "Validate()" on for validating a resource on creation
 	validateUpdateTypeKeyword string = "validateUpdateType" // Specifies a type to call "Validate()" on for validating a resource on update
+	noTypescriptKeyword       string = "notypescript"       // Excludes struct from all typescript output
 )
 
 func keywords() map[string]genlang.KeywordOpts {
@@ -744,5 +746,6 @@ func keywords() map[string]genlang.KeywordOpts {
 		defaultsUpdateTypeKeyword: {genlang.ScanStruct: genlang.ArgsRequired | genlang.StrictSingleArgs | genlang.Exclusive},
 		validateCreateTypeKeyword: {genlang.ScanStruct: genlang.ArgsRequired | genlang.StrictSingleArgs | genlang.Exclusive},
 		validateUpdateTypeKeyword: {genlang.ScanStruct: genlang.ArgsRequired | genlang.StrictSingleArgs | genlang.Exclusive},
+		noTypescriptKeyword:       {genlang.ScanStruct: genlang.NoArgs | genlang.Exclusive},
 	}
 }


### PR DESCRIPTION
This PR adds a new keyword `@notypescript` to exclude a resource from all typescript generation
```go
type (
    // @notypescript
    MyCoolResource struct {}
)
```