### PR TITLE
fix: Revert "feature: exclude resource from typescript generator with notypescript keyword (#478)"

### DIFF
--- a/resource/generation/extract.go
+++ b/resource/generation/extract.go
@@ -88,10 +88,6 @@ func (c *client) extractResources(structs []*parser.Struct) ([]*resourceInfo, er
 			resource.ValidateUpdateType = result.Struct.GetOne(validateUpdateTypeKeyword).Arg1
 		}
 
-		if result.Struct.Has(noTypescriptKeyword) {
-			resource.noTypescript = true
-		}
-
 		resources = append(resources, resource)
 	}
 

--- a/resource/generation/templates.go
+++ b/resource/generation/templates.go
@@ -893,9 +893,7 @@ export const Domains = {
 
 export const Resources = {
 {{- range $resource := $resources }}
-  {{- if not (index $.ExcludedResources $resource) }}
   {{ $resource }}: '{{ $resource }}' as Resource,
-  {{- end }}
 {{- end}}
 };
 
@@ -906,7 +904,6 @@ export const Methods = {
 };
 
 {{ range $resource, $tags := $resourcetags }}
-{{- if not (index $.ExcludedResources $resource) }}
 export namespace {{ $resource }} {
   export const fieldName = {
   {{- range $_, $tag := $tags }}
@@ -919,7 +916,6 @@ export namespace {{ $resource }} {
   {{- end }}
   };
 };
-{{- end }}
 {{ end }}
 {{ range $rpcMethod := $rpcMethods }}
 export namespace {{ $rpcMethod.Name }} {
@@ -935,7 +931,6 @@ type PermissionMappings = Record<Resource, ResourcePermissions>;
 
 const Mappings: PermissionMappings = {
   {{- range $resource := $resources }}
-  {{- if not (index $.ExcludedResources $resource) }}
   [Resources.{{ $resource }}]: {
     {{- range $perm := $resourcePermissions }}
     [Permissions.{{ $perm }}]: {{ index $resourcePermMap $resource $perm }},
@@ -948,7 +943,6 @@ const Mappings: PermissionMappings = {
       {{- end }}
   },
     {{- end }}
-  {{- end }}
   {{- end }}
 };
 

--- a/resource/generation/types.go
+++ b/resource/generation/types.go
@@ -241,7 +241,6 @@ type resourceInfo struct {
 	DefaultsUpdateType string
 	ValidateCreateType string
 	ValidateUpdateType string
-	noTypescript       bool
 }
 
 func (r *resourceInfo) ListHandlerDisabled() bool {
@@ -735,7 +734,6 @@ const (
 	defaultsUpdateTypeKeyword string = "defaultsUpdateType" // Specifies a type to call "Defaults()" on for setting defaults on resource update
 	validateCreateTypeKeyword string = "validateCreateType" // Specifies a type to call "Validate()" on for validating a resource on creation
 	validateUpdateTypeKeyword string = "validateUpdateType" // Specifies a type to call "Validate()" on for validating a resource on update
-	noTypescriptKeyword       string = "notypescript"       // Excludes struct from all typescript output
 )
 
 func keywords() map[string]genlang.KeywordOpts {
@@ -746,6 +744,5 @@ func keywords() map[string]genlang.KeywordOpts {
 		defaultsUpdateTypeKeyword: {genlang.ScanStruct: genlang.ArgsRequired | genlang.StrictSingleArgs | genlang.Exclusive},
 		validateCreateTypeKeyword: {genlang.ScanStruct: genlang.ArgsRequired | genlang.StrictSingleArgs | genlang.Exclusive},
 		validateUpdateTypeKeyword: {genlang.ScanStruct: genlang.ArgsRequired | genlang.StrictSingleArgs | genlang.Exclusive},
-		noTypescriptKeyword:       {genlang.ScanStruct: genlang.NoArgs | genlang.Exclusive},
 	}
 }


### PR DESCRIPTION
The reasoning for reverting this feature is that it does not appear to have a real-world use case. I cannot think of a situation where I want REST Endpoints for a resource, but I do not want TypeScript generation. If we disable REST Handler generation for a resource, that resource is already appropriately excluded from the TypeScript generation. 

More importantly, the use of this notypescript keyword would indicate a misunderstanding or misuse of the generated code.

This reverts commit b4c9b8da187e0cc195f5d65700dd2adeb394eeb8.