### PR TITLE
refactor!: reduce cruft around single and zero arg keywords in annotations

### DIFF
--- a/resource/generation/client.go
+++ b/resource/generation/client.go
@@ -292,14 +292,14 @@ func (c *client) retrieveDatabaseEnumValues(namedTypes []*parser.NamedType) (map
 	enumMap := make(map[string][]*enumData)
 	for _, namedType := range namedTypes {
 		scanner := genlang.NewScanner(resourceKeywords())
-		result, err := scanner.ScanNamedType(namedType)
+		annotations, err := scanner.ScanNamedType(namedType)
 		if err != nil {
 			return nil, errors.Wrap(err, "scanner.ScanNamedType()")
 		}
 
 		var tableName string
-		if result.Named.Has(enumerateKeyword) {
-			tableName = result.Named.GetOne(enumerateKeyword).Arg1
+		if annotations.Named.Has(enumerateKeyword) {
+			tableName = string(annotations.Named.Get(enumerateKeyword))
 		} else {
 			continue
 		}
@@ -471,7 +471,7 @@ func resourceEndpoints(res *resourceInfo) []HandlerType {
 	}
 
 	handlerTypes = slices.DeleteFunc(handlerTypes, func(ht HandlerType) bool {
-		return slices.Contains(res.SuppressedHandlers[:], ht)
+		return slices.Contains(res.SuppressedHandlers, ht)
 	})
 
 	return handlerTypes

--- a/resource/generation/parser/genlang/keywords.go
+++ b/resource/generation/parser/genlang/keywords.go
@@ -1,40 +1,47 @@
 package genlang
 
-import "iter"
+import (
+	"iter"
+	"strings"
+)
 
 type keywordFlag int
 
 // If a flag's requirement is violated the scanner will return an error.
 const (
-	// ArgsRequired requires a keyword to have an accompanying argument.
-	ArgsRequired keywordFlag = 1 << iota
-	// DualArgsRequired requires a keyword to have two comma-separated arguments.
-	DualArgsRequired
-	// NoArgs requires a keyword to be called without arguments.
-	NoArgs
-	// StrictSingleArgs limits the number of comma-separated arguments to one
-	StrictSingleArgs
-	// Exclusive limits the keyword to a single use per instance of field or struct.
-	Exclusive
+	ArgsRequired keywordFlag = 1 << iota // ArgsRequired requires a keyword to have an accompanying argument.
+	NoArgs                               // NoArgs requires a keyword to be called without arguments.
+	Exclusive                            // Exclusive limits the keyword to a single use per instance of field or struct.
 )
 
 // KeywordOpts is used to configure the flags for keywords based on the scan mode (field or struct).
 type KeywordOpts map[scanMode]keywordFlag
 
-// Args contains the raw string data for an argument, and possibly a second argument separated by a comma.
-type Args struct {
-	Arg1 string
-	Arg2 *string
+// Arg is the raw string passed to a keyword that accepts an argument.
+type Arg string
+
+// Count returns the number of arguments separated by `\x00`
+func (a Arg) Count() int {
+	if a == "" {
+		return 0
+	}
+
+	return strings.Count(string(a), "\x00") + 1
 }
 
-// MultiMap maps a singular key (string) to multiple values ([]Args),
+// Seq returns an iterator over the Arg separated by `\x00`
+func (a Arg) Seq() iter.Seq[string] {
+	return strings.SplitSeq(string(a), "\x00")
+}
+
+// ArgMap maps a singular key (string) to multiple values ([]Args),
 // with convenience methods for accessing the values.
-type MultiMap struct {
-	m map[string][]Args
+type ArgMap struct {
+	m map[string]Arg
 }
 
 // Keys returns an iterator over all of the keys in the MultiMap.
-func (m MultiMap) Keys() iter.Seq[string] {
+func (m ArgMap) Keys() iter.Seq[string] {
 	iterator := func(yield func(string) bool) {
 		for keyword := range m.m {
 			if !yield(keyword) {
@@ -46,63 +53,14 @@ func (m MultiMap) Keys() iter.Seq[string] {
 	return iterator
 }
 
-// Get returns the slice of Args for a given key.
-func (m MultiMap) Get(s string) []Args {
+// Get returns the argument for a given key.
+func (m ArgMap) Get(s string) Arg {
 	return m.m[s]
 }
 
-// GetOne returns the first instance of Args for a given key. The caller should check that Args *do* exist
-// for the given key before calling.
-func (m MultiMap) GetOne(s string) Args {
-	return m.m[s][0]
-}
-
 // Has returns true if the MultiMap contains one or more Args instances for a given key.
-func (m MultiMap) Has(s string) bool {
+func (m ArgMap) Has(s string) bool {
 	_, ok := m.m[s]
 
 	return ok
-}
-
-// GetSingleArgs returns an iterator over the first argument in each instance of Args for a given key.
-func (m MultiMap) GetSingleArgs(s string) iter.Seq[string] {
-	iterator := func(yield func(string) bool) {
-		for _, arg := range m.m[s] {
-			if !yield(arg.Arg1) {
-				return
-			}
-		}
-	}
-
-	return iterator
-}
-
-// GetDualArgs returns an iterator over the first and second argument in each instance of Args for a given key.
-func (m MultiMap) GetDualArgs(s string) iter.Seq2[string, *string] {
-	iterator := func(yield func(string, *string) bool) {
-		for _, arg := range m.m[s] {
-			if !yield(arg.Arg1, arg.Arg2) {
-				return
-			}
-		}
-	}
-
-	return iterator
-}
-
-// Iter returns an iterator over the Args for a given key.
-func (m MultiMap) Iter(s string) iter.Seq[Args] {
-	iterator := func(yield func(Args) bool) {
-		if _, ok := m.m[s]; !ok {
-			return
-		}
-
-		for _, arg := range m.m[s] {
-			if !yield(arg) {
-				return
-			}
-		}
-	}
-
-	return iterator
 }

--- a/resource/generation/parser/genlang/testdata/multiline.go
+++ b/resource/generation/parser/genlang/testdata/multiline.go
@@ -1,9 +1,11 @@
 package resources
 
 type (
-	/* @uniqueindex (Id, Description)
-	@foreignkey (Type) (StatusTypes(Id))
-	@foreignkey (Status) (Statuses(Id)) */
+	/*
+		Only lines starting with an @ symbol will be parsed for annotations
+		@uniqueindex (Id, Description) comments can also go after an annotation
+		@foreignkey (Type, StatusTypes(Id))
+		@foreignkey (Status, Statuses(Id)) */
 	foo struct {
 		/* @primarykey
 		@check (@self = 'N')

--- a/resource/generation/types.go
+++ b/resource/generation/types.go
@@ -42,7 +42,7 @@ const (
 	PatchHandler HandlerType = "patchHandler"
 )
 
-func (HandlerType) enumerate() []HandlerType {
+func handlerTypes() []HandlerType {
 	return []HandlerType{
 		AllHandlers,
 		ListHandler,
@@ -329,7 +329,7 @@ func (c *computedField) TypescriptDataType() string {
 type resourceInfo struct {
 	*parser.TypeInfo
 	Fields             []*resourceField
-	SuppressedHandlers [3]HandlerType
+	SuppressedHandlers []HandlerType
 	IsView             bool // Determines how CreatePatch is rendered in resource generation.
 	IsConsolidated     bool
 	PkCount            int
@@ -350,23 +350,23 @@ func (r *resourceInfo) HasNullBool() bool {
 }
 
 func (r *resourceInfo) ListHandlerDisabled() bool {
-	return slices.Contains(r.SuppressedHandlers[:], ListHandler)
+	return slices.Contains(r.SuppressedHandlers, ListHandler)
 }
 
 func (r *resourceInfo) ReadHandlerDisabled() bool {
-	return slices.Contains(r.SuppressedHandlers[:], ReadHandler)
+	return slices.Contains(r.SuppressedHandlers, ReadHandler)
 }
 
 func (r *resourceInfo) CreateHandlerDisabled() bool {
-	return slices.Contains(r.SuppressedHandlers[:], PatchHandler)
+	return slices.Contains(r.SuppressedHandlers, PatchHandler)
 }
 
 func (r *resourceInfo) UpdateHandlerDisabled() bool {
-	return slices.Contains(r.SuppressedHandlers[:], PatchHandler)
+	return slices.Contains(r.SuppressedHandlers, PatchHandler)
 }
 
 func (r *resourceInfo) DeleteHandlerDisabled() bool {
-	return slices.Contains(r.SuppressedHandlers[:], PatchHandler)
+	return slices.Contains(r.SuppressedHandlers, PatchHandler)
 }
 
 // HasDefaultsCreateType indicates if a default create type has been registered
@@ -808,10 +808,10 @@ func resourceKeywords() map[string]genlang.KeywordOpts {
 		rpcKeyword:                {genlang.ScanStruct: genlang.NoArgs | genlang.Exclusive},
 		enumerateKeyword:          {genlang.ScanNamedType: genlang.ArgsRequired | genlang.Exclusive},
 		suppressKeyword:           {genlang.ScanStruct: genlang.ArgsRequired},
-		defaultsCreateTypeKeyword: {genlang.ScanStruct: genlang.ArgsRequired | genlang.StrictSingleArgs | genlang.Exclusive},
-		defaultsUpdateTypeKeyword: {genlang.ScanStruct: genlang.ArgsRequired | genlang.StrictSingleArgs | genlang.Exclusive},
-		validateCreateTypeKeyword: {genlang.ScanStruct: genlang.ArgsRequired | genlang.StrictSingleArgs | genlang.Exclusive},
-		validateUpdateTypeKeyword: {genlang.ScanStruct: genlang.ArgsRequired | genlang.StrictSingleArgs | genlang.Exclusive},
+		defaultsCreateTypeKeyword: {genlang.ScanStruct: genlang.ArgsRequired | genlang.Exclusive},
+		defaultsUpdateTypeKeyword: {genlang.ScanStruct: genlang.ArgsRequired | genlang.Exclusive},
+		validateCreateTypeKeyword: {genlang.ScanStruct: genlang.ArgsRequired | genlang.Exclusive},
+		validateUpdateTypeKeyword: {genlang.ScanStruct: genlang.ArgsRequired | genlang.Exclusive},
 		primarykeyKeyword:         {genlang.ScanField: genlang.NoArgs},
 	}
 }


### PR DESCRIPTION
This makes it easier to use single or zero arg annotations by flattening the args into a single string and removing optional arguments.

Before: `result.Struct.GetOne(fooKeyword).Arg`

After: `result.Struct.Get(fooKeyword)`

Comment annotations can now also include comments, wow!:

```go
type (
  // previously this comment was illegal
  // @keyword
  foo struct {
    // this comment too
    a int
    // now it's all in the game
    b int
)
```