### PR TITLE
feature!: support multi-schema generation & caching

### DIFF
--- a/resource/generation/cache.go
+++ b/resource/generation/cache.go
@@ -135,7 +135,6 @@ func (c *client) isSchemaClean() (bool, error) {
 		if err != nil {
 			return false, errors.Wrap(err, "os.Open()")
 		}
-		defer dir.Close()
 
 		fileNames, err := dir.Readdirnames(0)
 		if err != nil {
@@ -158,6 +157,10 @@ func (c *client) isSchemaClean() (bool, error) {
 			if _, ok := cachedHashes[fmt.Sprintf("%x", hash)]; !ok {
 				return false, nil
 			}
+		}
+
+		if err := dir.Close(); err != nil {
+			log.Print(errors.Wrap(err, "os.File.Close()"))
 		}
 	}
 

--- a/resource/generation/cache.go
+++ b/resource/generation/cache.go
@@ -77,16 +77,33 @@ func hashFilesInDir(path string) (map[string]struct{}, error) {
 	return hashMap, nil
 }
 
-func (c *client) cacheSchemaHashes() error {
-	migrationPath := strings.TrimPrefix(c.migrationSourceURL, "file://")
-	schemaMigrationHashes, err := hashFilesInDir(migrationPath)
-	if err != nil {
-		return err
+func hashString(s string) ([]byte, error) {
+	h := sha256.New()
+	if _, err := h.Write([]byte(s)); err != nil {
+		return nil, errors.Wrap(err, "hash.Hash.Write()")
 	}
 
-	for hash := range schemaMigrationHashes {
-		if err := c.genCache.Store("migrations", fmt.Sprintf("%x", []byte(hash)), ""); err != nil {
-			return errors.Wrap(err, "could not store sha256 hash in gencache: cache.Cache.Store()")
+	return h.Sum(nil), nil
+}
+
+func (c *client) cacheSchemaHashes() error {
+	for _, migrationSource := range c.migrationSourceURLs {
+		migrationPath := strings.TrimPrefix(migrationSource, "file://")
+		schemaMigrationHashes, err := hashFilesInDir(migrationPath)
+		if err != nil {
+			return err
+		}
+
+		hashedMigrationSourceURL, err := hashString(migrationSource)
+		if err != nil {
+			return err
+		}
+		migrationCachePath := filepath.Join("migrations", fmt.Sprintf("%x", hashedMigrationSourceURL))
+
+		for hash := range schemaMigrationHashes {
+			if err := c.genCache.Store(migrationCachePath, fmt.Sprintf("%x", []byte(hash)), ""); err != nil {
+				return errors.Wrap(err, "could not store sha256 hash in gencache: cache.Cache.Store()")
+			}
 		}
 	}
 
@@ -96,44 +113,51 @@ func (c *client) cacheSchemaHashes() error {
 // Loads previous schema migration checksums from gencache, if they exist.
 // Returns false current schema migration checksums do not match cached checksums.
 func (c *client) isSchemaClean() (bool, error) {
-	keys, err := c.genCache.Keys("migrations")
-	if err != nil {
-		return false, errors.Wrap(err, "could not load migration hashes from genCache: cache.Cache.Keys()")
-	}
-
-	cachedHashes := make(map[string]struct{})
-	for key := range keys {
-		cachedHashes[key] = struct{}{}
-	}
-
-	// gather files from schema migration directory
-	migrationPath := strings.TrimPrefix(c.migrationSourceURL, "file://")
-	dir, err := os.Open(migrationPath)
-	if err != nil {
-		return false, errors.Wrap(err, "os.Open()")
-	}
-	defer dir.Close()
-
-	fileNames, err := dir.Readdirnames(0)
-	if err != nil {
-		return false, errors.Wrap(err, "os.File.Readdirnames()")
-	}
-
-	if len(fileNames) != len(cachedHashes) {
-		log.Printf("\x1b[33mNumber of schema files (%d) does not match number of cached files (%d). Invalidating cache.\x1b[39m\n", len(fileNames), len(cachedHashes))
-
-		return false, nil
-	}
-
-	// check cache for hash of each schema migration file
-	for _, fileName := range fileNames {
-		hash, err := hashFile(filepath.Join(migrationPath, fileName))
+	for _, migrationSource := range c.migrationSourceURLs {
+		hashedMigrationSourceURL, err := hashString(migrationSource)
 		if err != nil {
 			return false, err
 		}
 
-		if _, ok := cachedHashes[fmt.Sprintf("%x", hash)]; !ok {
+		keys, err := c.genCache.Keys(filepath.Join("migrations", fmt.Sprintf("%x", hashedMigrationSourceURL)))
+		if err != nil {
+			return false, errors.Wrap(err, "could not load migration hashes from genCache: cache.Cache.Keys()")
+		}
+
+		cachedHashes := make(map[string]struct{})
+		for key := range keys {
+			cachedHashes[key] = struct{}{}
+		}
+
+		// gather files from schema migration directory
+		migrationPath := strings.TrimPrefix(migrationSource, "file://")
+		dir, err := os.Open(migrationPath)
+		if err != nil {
+			return false, errors.Wrap(err, "os.Open()")
+		}
+		defer dir.Close()
+
+		fileNames, err := dir.Readdirnames(0)
+		if err != nil {
+			return false, errors.Wrap(err, "os.File.Readdirnames()")
+		}
+
+		if len(fileNames) != len(cachedHashes) {
+			log.Printf("\x1b[33mNumber of schema files (%d) does not match number of cached files (%d). Invalidating cache.\x1b[39m\n", len(fileNames), len(cachedHashes))
+
 			return false, nil
+		}
+
+		// check cache for hash of each schema migration file
+		for _, fileName := range fileNames {
+			hash, err := hashFile(filepath.Join(migrationPath, fileName))
+			if err != nil {
+				return false, err
+			}
+
+			if _, ok := cachedHashes[fmt.Sprintf("%x", hash)]; !ok {
+				return false, nil
+			}
 		}
 	}
 

--- a/resource/generation/client.go
+++ b/resource/generation/client.go
@@ -35,19 +35,19 @@ const (
 var caser = strcase.NewCaser(false, nil, nil)
 
 type client struct {
-	loadPackages       []string
-	resource           packageDir
-	resources          []*resourceInfo
-	computedResources  []*computedResource
-	rpcMethods         []*rpcMethodInfo
-	localPackages      []string
-	rpc                packageDir
-	computed           packageDir
-	virtual            packageDir
-	migrationSourceURL string
-	tableMap           map[string]*tableMetadata
-	enumValues         map[string][]*enumData
-	pluralOverrides    map[string]string
+	loadPackages        []string
+	resource            packageDir
+	resources           []*resourceInfo
+	computedResources   []*computedResource
+	rpcMethods          []*rpcMethodInfo
+	localPackages       []string
+	rpc                 packageDir
+	computed            packageDir
+	virtual             packageDir
+	migrationSourceURLs []string
+	tableMap            map[string]*tableMetadata
+	enumValues          map[string][]*enumData
+	pluralOverrides     map[string]string
 	consolidateConfig
 	genRPCMethods          bool
 	genComputedResources   bool
@@ -57,7 +57,7 @@ type client struct {
 	genCache *cache.Cache
 }
 
-func newClient(ctx context.Context, genType generatorType, resourcePackageDir, migrationSourceURL string, localPackages []string, opts []option) (*client, error) {
+func newClient(ctx context.Context, genType generatorType, resourcePackageDir string, migrationSourceURL, localPackages []string, opts []option) (*client, error) {
 	pkgInfo, err := pkg.Info()
 	if err != nil {
 		return nil, errors.Wrap(err, "pkg.Info()")
@@ -73,8 +73,8 @@ func newClient(ctx context.Context, genType generatorType, resourcePackageDir, m
 	}
 
 	c := &client{
-		migrationSourceURL: migrationSourceURL,
-		genCache:           gCache,
+		migrationSourceURLs: migrationSourceURL,
+		genCache:            gCache,
 	}
 	if err := resolveOptions(c, opts); err != nil {
 		return nil, err
@@ -98,9 +98,19 @@ func newClient(ctx context.Context, genType generatorType, resourcePackageDir, m
 		if genType == typeScriptGeneratorType {
 			return nil, errors.New("schema cache is out of date, please run Resource Generator first")
 		}
-		if err := c.genCache.DeleteSubpath("migrations"); err != nil {
-			return nil, errors.Wrap(err, "cache.Cache.DeleteSubpath()")
+
+		for _, migrationSource := range migrationSourceURL {
+			hashedMigrationSourceURL, err := hashString(migrationSource)
+			if err != nil {
+				return nil, err
+			}
+			migrationCachePath := filepath.Join("migrations", fmt.Sprintf("%x", hashedMigrationSourceURL))
+
+			if err := c.genCache.DeleteSubpath(migrationCachePath); err != nil {
+				return nil, errors.Wrap(err, "cache.Cache.DeleteSubpath()")
+			}
 		}
+
 		if err := c.runSpanner(ctx, c.spannerEmulatorVersion, migrationSourceURL); err != nil {
 			return nil, err
 		}
@@ -109,7 +119,7 @@ func newClient(ctx context.Context, genType generatorType, resourcePackageDir, m
 	c.loadPackages = append(c.loadPackages, resourcePackageDir)
 	c.resource = packageDir(resourcePackageDir)
 	c.localPackages = localPackages
-	c.migrationSourceURL = migrationSourceURL
+	c.migrationSourceURLs = migrationSourceURL
 
 	return c, nil
 }

--- a/resource/generation/options_test.go
+++ b/resource/generation/options_test.go
@@ -38,7 +38,7 @@ func TestApplicationName(t *testing.T) {
 			r, err := NewResourceGenerator(
 				context.Background(),
 				"testdata/resources.go",
-				"file://generation/testdata/migrations",
+				[]string{"file://generation/testdata/migrations"},
 				[]string{},
 				opts...,
 			)

--- a/resource/generation/resource.go
+++ b/resource/generation/resource.go
@@ -25,7 +25,7 @@ type resourceGenerator struct {
 }
 
 // NewResourceGenerator constructs a new Generator for generating a resource-driven API.
-func NewResourceGenerator(ctx context.Context, resourcePackageDir, migrationSourceURL string, localPackages []string, options ...ResourceOption) (Generator, error) {
+func NewResourceGenerator(ctx context.Context, resourcePackageDir string, migrationSourceURL, localPackages []string, options ...ResourceOption) (Generator, error) {
 	r := &resourceGenerator{}
 
 	opts := make([]option, 0, len(options))

--- a/resource/generation/spanner.go
+++ b/resource/generation/spanner.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-playground/errors/v5"
 )
 
-func createSpannerDB(ctx context.Context, emulatorVersion, migrationSourceURL string) (*initiator.SpannerDB, error) {
+func createSpannerDB(ctx context.Context, emulatorVersion string, migrationSourceURLs []string) (*initiator.SpannerDB, error) {
 	log.Println("Starting Spanner Container...")
 	spannerContainer, err := initiator.NewSpannerContainer(ctx, emulatorVersion)
 	if err != nil {
@@ -24,14 +24,16 @@ func createSpannerDB(ctx context.Context, emulatorVersion, migrationSourceURL st
 	}
 
 	log.Println("Starting Spanner Migration...")
-	if err := db.MigrateUp(migrationSourceURL); err != nil {
-		return nil, errors.Wrap(err, "initiator.SpannerDB.MigrateUp()")
+	for _, migrationSource := range migrationSourceURLs {
+		if err := db.MigrateUp(migrationSource); err != nil {
+			return nil, errors.Wrap(err, "initiator.SpannerDB.MigrateUp()")
+		}
 	}
 
 	return db, nil
 }
 
-func (c *client) runSpanner(ctx context.Context, emulatorVersion, migrationSourceURL string) error {
+func (c *client) runSpanner(ctx context.Context, emulatorVersion string, migrationSourceURL []string) error {
 	db, err := createSpannerDB(ctx, emulatorVersion, migrationSourceURL)
 	if err != nil {
 		return err

--- a/resource/generation/typescript.go
+++ b/resource/generation/typescript.go
@@ -28,7 +28,7 @@ type typescriptGenerator struct {
 }
 
 // NewTypescriptGenerator constructs a new Generator for generating Typescript for a resource-driven Angular app.
-func NewTypescriptGenerator(ctx context.Context, resourceSourcePath, migrationSourceURL, targetDir string, rc *resource.Collection, options ...TSOption) (Generator, error) {
+func NewTypescriptGenerator(ctx context.Context, resourceSourcePath string, migrationSourceURL []string, targetDir string, rc *resource.Collection, options ...TSOption) (Generator, error) {
 	if rc == nil {
 		return nil, errors.New("resource collection cannot be nil")
 	}


### PR DESCRIPTION
For apps that use multiple schema migration directories during development, the cache is invalidated through multiple runs of the generator. Currently all migrations are cached under `.ccc-cache/migrations`. This PR hashes each migration path individually such that the cache subpath is `.ccc-cache/migrations/<sha256 hash of source URL>`. It also changes the `NewGenerator()` constructors to take a slice of migration source URLs instead of a single one.

Migration guide:

```diff
r, err := NewResourceGenerator(
			context.Background(),
			"testdata/resources.go",
-			"file://generation/testdata/migrations",
+			[]string{"file://generation/testdata/migrations"},
			[]string{},
			opts...,
		)
```