### PR TITLE
feature: multitenant scope in resource generation

### DIFF
--- a/resource/generation/client.go
+++ b/resource/generation/client.go
@@ -531,14 +531,6 @@ func resourceEndpoints(res *resourceInfo) []HandlerType {
 	return handlerTypes
 }
 
-func hasConsolidatedHandler(res *resourceInfo) bool {
-	if res.IsConsolidated {
-		return !slices.Contains(res.SuppressedHandlers, PatchHandler)
-	}
-
-	return false
-}
-
 func sanitizeEnumIdentifier(name string) string {
 	var result []byte
 	for _, b := range []byte(name) {

--- a/resource/generation/client.go
+++ b/resource/generation/client.go
@@ -48,6 +48,7 @@ type client struct {
 	tableMap            map[string]*tableMetadata
 	enumValues          map[string][]*enumData
 	pluralOverrides     map[string]string
+	tenantScope         *multitenantScope
 	consolidateConfig
 	genRPCMethods          bool
 	genComputedResources   bool

--- a/resource/generation/extract.go
+++ b/resource/generation/extract.go
@@ -59,6 +59,15 @@ func (c *client) structsToResources(structs []*parser.Struct, validators ...stru
 			continue
 		}
 
+		if c.tenantScope != nil && !annotations.Struct.Has(unscopedKeyword) {
+			if err := validateScope(*c.tenantScope, pStruct, table, fields); err != nil {
+				resourceErrors = append(resourceErrors, err)
+
+				continue
+			}
+			resource.IsScoped = true
+		}
+
 		if err := resolveResourceAnnotations(resource, annotations); err != nil {
 			resourceErrors = append(resourceErrors, err)
 
@@ -408,6 +417,37 @@ func validateNullability(pStruct *parser.Struct, table *tableMetadata) error {
 		}
 
 		return errors.Newf("found mismatching nullability between the struct fields and columns:\n%s", msg.String())
+	}
+
+	return nil
+}
+
+func validateScope(scope multitenantScope, pStruct *parser.Struct, table *tableMetadata, fields []*resourceField) error {
+	if col, ok := table.Columns[caser.ToPascal(scope.fieldName)]; ok {
+		if !col.IsForeignKey {
+			return errors.Newf("%s table is missing mandatory foreign key reference to %q on column %q", pStruct.Name(), scope.resourceName, scope.fieldName)
+		}
+	} else {
+		return errors.Newf("%s table is missing mandatory tentant column %q", pStruct.Name(), scope.fieldName)
+	}
+
+	hasScopedField := false
+	for _, field := range fields {
+		if !field.IsForeignKey {
+			continue
+		}
+
+		if tag, _ := field.LookupTag("spanner"); !strings.EqualFold(tag, scope.fieldName) {
+			continue
+		}
+
+		hasScopedField = true
+
+		break
+	}
+
+	if !hasScopedField {
+		return errors.Newf("%s struct is missing mandatory tenant field %q", pStruct.Name(), scope.fieldName)
 	}
 
 	return nil

--- a/resource/generation/extract.go
+++ b/resource/generation/extract.go
@@ -428,7 +428,7 @@ func validateScope(scope multitenantScope, pStruct *parser.Struct, table *tableM
 			return errors.Newf("%s table is missing mandatory foreign key reference to %q on column %q", pStruct.Name(), scope.resourceName, scope.fieldName)
 		}
 	} else {
-		return errors.Newf("%s table is missing mandatory tentant column %q", pStruct.Name(), scope.fieldName)
+		return errors.Newf("%s table is missing mandatory tenant column %q", pStruct.Name(), scope.fieldName)
 	}
 
 	hasScopedField := false

--- a/resource/generation/handler.go
+++ b/resource/generation/handler.go
@@ -159,6 +159,11 @@ func (r *resourceGenerator) generateConsolidatedPatchHandler(resources []*resour
 		return errors.Wrap(err, "template.New().Parse()")
 	}
 
+	var tenantID string
+	if r.tenantScope != nil {
+		tenantID = r.tenantScope.fieldName
+	}
+
 	buf := bytes.NewBuffer(nil)
 	if err := tmpl.Execute(buf, map[string]any{
 		"Source":              r.resource.Dir(),
@@ -168,6 +173,7 @@ func (r *resourceGenerator) generateConsolidatedPatchHandler(resources []*resour
 		"ResourcePackage":     r.resource.Package(),
 		"ApplicationName":     r.applicationName,
 		"ReceiverName":        r.receiverName,
+		"TenantID":            tenantID,
 	}); err != nil {
 		return errors.Wrap(err, "tmpl.Execute()")
 	}

--- a/resource/generation/handler.go
+++ b/resource/generation/handler.go
@@ -192,6 +192,11 @@ func (r *resourceGenerator) handlerContent(handler HandlerType, res *resourceInf
 		return nil, errors.Wrap(err, "template.New().Parse()")
 	}
 
+	var tenantID *string
+	if res.IsScoped {
+		tenantID = &r.tenantScope.fieldName
+	}
+
 	buf := bytes.NewBuffer([]byte{})
 	if err := tmpl.Execute(buf, map[string]any{
 		"ResourcePackage":         r.resource.Package(),
@@ -199,6 +204,7 @@ func (r *resourceGenerator) handlerContent(handler HandlerType, res *resourceInf
 		"VirtualResourcesPackage": r.virtual.Package(),
 		"ApplicationName":         r.applicationName,
 		"ReceiverName":            r.receiverName,
+		"TenantID":                tenantID,
 	}); err != nil {
 		return nil, errors.Wrap(err, "tmpl.Execute()")
 	}

--- a/resource/generation/options.go
+++ b/resource/generation/options.go
@@ -246,6 +246,25 @@ func WithRPC(rpcPackageDir string) Option {
 	}
 }
 
+// WithTenantScope requires that each Resource references the a tenant Resource via foreign key named `fieldName`.
+func WithTenantScope(resourceName, fieldName string) Option {
+	return func(g any) error {
+		switch t := g.(type) {
+		case *resourceGenerator:
+		case *typescriptGenerator: // no-op
+		case *client:
+			t.tenantScope = &multitenantScope{
+				resourceName: resourceName,
+				fieldName:    fieldName,
+			}
+		default:
+			panic(fmt.Sprintf("unexpected generator type in WithTenantScope(): %T", t))
+		}
+
+		return nil
+	}
+}
+
 // resolveOptions is called twice, once in the client constructor and once in either the resource or typescript generator's constructor.
 // That is why no-op cases are included to prevent falling through to the default panic case.
 func resolveOptions(generator any, options []option) error {

--- a/resource/generation/options.go
+++ b/resource/generation/options.go
@@ -246,7 +246,7 @@ func WithRPC(rpcPackageDir string) Option {
 	}
 }
 
-// WithTenantScope requires that each Resource references the a tenant Resource via foreign key named `fieldName`.
+// WithTenantScope requires that each Resource references the tenant Resource via foreign key named `fieldName`.
 func WithTenantScope(resourceName, fieldName string) Option {
 	return func(g any) error {
 		switch t := g.(type) {

--- a/resource/generation/resource.go
+++ b/resource/generation/resource.go
@@ -211,11 +211,16 @@ func (r *resourceGenerator) generateResources(res *resourceInfo) error {
 		packageName = r.virtual.Package()
 		destinationFilePath = filepath.Join(r.virtual.Dir(), fileName)
 	}
+	var tenantID string
+	if r.tenantScope != nil {
+		tenantID = r.tenantScope.fieldName
+	}
 
 	output, err := r.generateTemplateOutput("resourceFileTemplate", resourceFileTemplate, map[string]any{
 		"Source":   r.resource.Dir(),
 		"Package":  packageName,
 		"Resource": res,
+		"TenantID": tenantID,
 	})
 	if err != nil {
 		return errors.Wrap(err, "generateTemplateOutput()")

--- a/resource/generation/router.go
+++ b/resource/generation/router.go
@@ -21,12 +21,13 @@ func (r *resourceGenerator) runRouteGeneration() error {
 	}
 
 	var hasConsolidatedHandlers bool
+	// constResources are resources that will get an [httpio.ParamType] constant generated in the router package
 	constResources := make([]*resourceInfo, 0, len(r.resources))
 	resources := make([]*resourceInfo, 0, len(r.resources))
 	generatedRoutesMap := make(map[string][]generatedRoute)
 	for _, res := range r.resources {
 		handlerTypes := resourceEndpoints(res)
-		if hasConsolidatedHandler(res) {
+		if res.IsConsolidated && !slices.Contains(res.SuppressedHandlers, PatchHandler) {
 			hasConsolidatedHandlers = true
 		}
 

--- a/resource/generation/templates.go
+++ b/resource/generation/templates.go
@@ -81,6 +81,14 @@ func (q *{{ .Resource.Name }}Query) Read(ctx context.Context, txn resource.ReadO
 		if _, ok := keyMap[accesstypes.Field("{{ .TenantID }}")]; !ok {
 			panic("{{ .Resource.Name }}Query KeySet does not include mandatory {{ .TenantID }}. Hint: set with .Set{{ .TenantID }}(...)")
 		}
+	} else if filterAst, err := q.qSet.FilterAst(resource.SpannerDBType); err != nil {
+		panic(errors.Wrap(err, "resource.QuerySet[{{ .Resource.Name }}].FilterAst()"))
+	} else if filterAst != nil {
+		if !resource.ContainsCondition(filterAst, &resource.Condition{Field: "{{ Camel $.TenantID }}", Operator: "eq"}) {
+			panic("{{ .Resource.Name }}Query does not include mandatory \"{{ Camel $.TenantID }}:eq\" in URL query params")
+		}
+	} else {
+		panic("{{ .Resource.Name }}Query does not include mandatory {{ .TenantID }} in QuerySet. Hint: Use URL query params, or KeySet, or Where() clause")
 	}
 	{{ end -}}
 
@@ -93,6 +101,14 @@ func (q *{{ .Resource.Name }}Query) List(ctx context.Context, txn resource.ReadO
 		if _, ok := keyMap[accesstypes.Field("{{ .TenantID }}")]; !ok {
 			panic("{{ .Resource.Name }}Query KeySet does not include mandatory {{ .TenantID }}. Hint: set with .Set{{ .TenantID }}(...)")
 		}
+	} else if filterAst, err := q.qSet.FilterAst(resource.SpannerDBType); err != nil {
+		panic(errors.Wrap(err, "resource.QuerySet[{{ .Resource.Name }}].FilterAst()"))
+	} else if filterAst != nil {
+		if !resource.ContainsCondition(filterAst, &resource.Condition{Field: "{{ Camel $.TenantID }}", Operator: "eq"}) {
+			panic("{{ .Resource.Name }}Query does not include mandatory \"{{ Camel $.TenantID }}:eq\" in URL query params")
+		}
+	} else {
+		panic("{{ .Resource.Name }}Query does not include mandatory {{ .TenantID }} in QuerySet. Hint: Use URL query params, or KeySet, or Where() clause")
 	}
 	{{ end -}}
 
@@ -105,6 +121,14 @@ func (q *{{ .Resource.Name }}Query) BatchList(ctx context.Context, client resour
 		if _, ok := keyMap[accesstypes.Field("{{ .TenantID }}")]; !ok {
 			panic("{{ .Resource.Name }}Query KeySet does not include mandatory {{ .TenantID }}. Hint: set with .Set{{ .TenantID }}(...)")
 		}
+	} else if filterAst, err := q.qSet.FilterAst(resource.SpannerDBType); err != nil {
+		panic(errors.Wrap(err, "resource.QuerySet[{{ .Resource.Name }}].FilterAst()"))
+	} else if filterAst != nil {
+		if !resource.ContainsCondition(filterAst, &resource.Condition{Field: "{{ Camel $.TenantID }}", Operator: "eq"}) {
+			panic("{{ .Resource.Name }}Query does not include mandatory \"{{ Camel $.TenantID }}:eq\" in URL query params")
+		}
+	} else {
+		panic("{{ .Resource.Name }}Query does not include mandatory {{ .TenantID }} in QuerySet. Hint: Use URL query params, or KeySet, or Where() clause")
 	}
 	{{ end -}}
 

--- a/resource/generation/templates.go
+++ b/resource/generation/templates.go
@@ -126,7 +126,7 @@ func (q *{{ .Resource.Name }}Query) Where(c {{ .Resource.Name }}QueryClause) *{{
 	}
 	{{- if .Resource.IsScoped }}
 	if !c.clause.ContainsCondition(&resource.Condition{Field: "{{ .TenantID }}", Operator: "eq"}) {
-		panic("{{ .Resource.Name }}Query QueryClause does not contain mandatory {{ .TenantID }} equals condition. Hint: Add .{{ .TenantID }}.Equals(...)")
+		panic("{{ .Resource.Name }}Query QueryClause does not contain mandatory {{ .TenantID }} equals condition. Hint: Add .{{ .TenantID }}().Equals(...)")
 	}
 	{{- end }}
 	q.qSet.SetWhereClause(c.clause)
@@ -311,7 +311,7 @@ func New{{ .Resource.Name }}CreatePatchFromPatchSet(patchSet *resource.PatchSet[
 	if err != nil {
 		return nil, errors.Wrap(err, "ccc.NewUUID()")
 	}
-	
+
 	patchSet.
 		SetKey("{{ .Resource.PrimaryKey.Name }}", id).
 		SetPatchType(resource.CreatePatchType)
@@ -326,7 +326,7 @@ func New{{ .Resource.Name }}CreatePatch() (*{{ .Resource.Name }}CreatePatch, err
 	if err != nil {
 		return nil, errors.Wrap(err, "ccc.NewUUID()")
 	}
-	
+
 	patchSet := resource.NewPatchSet(resource.NewMetadata[{{ .Resource.Name }}]()).
 		SetKey("{{ .Resource.PrimaryKey.Name }}", id).
 		SetPatchType(resource.CreatePatchType)
@@ -349,7 +349,7 @@ func New{{ .Resource.Name }}CreatePatchFromPatchSet(
 		SetPatchType(resource.CreatePatchType)
 	patch := &{{ .Resource.Name }}CreatePatch{patchSet: patchSet}
 	patch.registerDefaultFuncs()
-	
+
 	return patch
 }
 
@@ -545,9 +545,9 @@ func (p *{{ .Resource.Name }}DeletePatch) Buffer(ctx context.Context, txn resour
 }
 
 {{ range $field := .Resource.Fields }}
-{{ if $field.IsPrimaryKey }} 
+{{ if $field.IsPrimaryKey }}
 func (p *{{ $field.Parent.Name }}DeletePatch) {{ $field.Name }}() {{ $field.ResolvedType }} {
-	v, _ := p.patchSet.Key("{{ $field.Name }}").({{ $field.ResolvedType }}) 
+	v, _ := p.patchSet.Key("{{ $field.Name }}").({{ $field.ResolvedType }})
 
 	return v
 }
@@ -601,7 +601,7 @@ import (
 		if err != nil {
 			return httpio.NewEncoder(w).ClientMessage(ctx, err)
 		}
-		
+
 		{{ if .Resource.IsScoped }}
 		customSession, err := customsession.DataFromCtx(ctx)
 		if err != nil {
@@ -697,7 +697,7 @@ import (
 		{{ $field.Name }} {{ $field.Type}} ` + "`{{ $field.JSONTagForPatch }} {{ $field.ImmutableTag }} {{ $field.PatchPermTag }}`" + `
 		{{- end }}
 	}
-	
+
 	{{ $PrimaryKeyIsGeneratedUUID := .Resource.PrimaryKeyIsGeneratedUUID }}
 	{{ $PrimaryKeyType := .Resource.PrimaryKeyType }}
 	{{- if $PrimaryKeyIsGeneratedUUID }}
@@ -1107,8 +1107,8 @@ const resourceMap: ResourceMap = {
     {{- end }}
     fields: [
       {{- range $field := $resource.Fields }}
-      { fieldName: '{{ Camel $field.Name }}', 
-       {{- if $field.IsPrimaryKey }} primaryKey: { ordinalPosition: {{ $field.KeyOrdinalPosition }} }, 
+      { fieldName: '{{ Camel $field.Name }}',
+       {{- if $field.IsPrimaryKey }} primaryKey: { ordinalPosition: {{ $field.KeyOrdinalPosition }} },
        {{- end }} displayType: '{{ Lower $field.TypescriptDisplayType }}', required: {{ $field.IsRequired }}, isIndex: {{ $field.IsIndex -}}
       {{- if $field.IsEnumerated }}, enumeratedResource: Resources.{{ $field.ReferencedResource }}{{ end }} },
       {{- end }}
@@ -1124,8 +1124,8 @@ const resourceMap: ResourceMap = {
 	createDisabled: true, updateDisabled: true, deleteDisabled: true,
     fields: [
       {{- range $field := $resource.Fields }}
-      { fieldName: '{{ Camel $field.Name }}', 
-       {{- if $field.IsPrimaryKey }} primaryKey: { ordinalPosition: {{ $field.KeyOrdinalPosition }} }, 
+      { fieldName: '{{ Camel $field.Name }}',
+       {{- if $field.IsPrimaryKey }} primaryKey: { ordinalPosition: {{ $field.KeyOrdinalPosition }} },
        {{- end }} displayType: '{{ Lower $field.TypescriptDataType }}', required: {{ $field.IsPrimaryKey }}, isIndex: false },
       {{- end }}
     ],
@@ -1410,8 +1410,8 @@ import (
 func ({{ .ReceiverName }} *{{ .ApplicationName }}) {{ .RPCMethod.Name }}() http.HandlerFunc {
 	{{- range $field := .RPCMethod.Fields }}
 	{{- if $field.IsLocalType }}
-	type {{ Lower $field.UnqualifiedTypeName }} 
-	
+	type {{ Lower $field.UnqualifiedTypeName }}
+
 	{{- with $field.AsStruct }} struct {
 		{{- range $field := .Fields }}
 		{{ $field.Name }} {{ $field.Type }} ` + "`json:\"{{ Camel $field.Name }}\"`" + `
@@ -1429,7 +1429,7 @@ func ({{ .ReceiverName }} *{{ .ApplicationName }}) {{ .RPCMethod.Name }}() http.
 
 	decoder := NewRPCDecoder[{{ .RPCMethod.Type }}, request]({{ .ReceiverName }}, accesstypes.Execute)
 
-	return httpio.Log(func(w http.ResponseWriter, r *http.Request) error { 
+	return httpio.Log(func(w http.ResponseWriter, r *http.Request) error {
 		ctx, span := ccc.StartTrace(r.Context())
 		defer span.End()
 
@@ -1625,10 +1625,10 @@ func fieldAccessors(patchType patchType) string {
 		{{ end }}
 
 		func (p *{{ $field.Parent.Name }}%[1]sPatch) {{ $field.Name }}() {{ $field.ResolvedType }} {
-		{{ if $field.IsPrimaryKey -}} 
+		{{ if $field.IsPrimaryKey -}}
 			v, _ := p.patchSet.Key("{{ $field.Name }}").({{ $field.ResolvedType }})
-		{{ else -}} 
-			v, _ := p.patchSet.Get("{{ $field.Name }}").({{ $field.ResolvedType }}) 
+		{{ else -}}
+			v, _ := p.patchSet.Get("{{ $field.Name }}").({{ $field.ResolvedType }})
 		{{ end }}
 
 			return v

--- a/resource/generation/templates.go
+++ b/resource/generation/templates.go
@@ -597,19 +597,27 @@ import (
 		ctx, span := ccc.StartTrace(r.Context())
 		defer span.End()
 
-		querySet, err := decoder.Decode(r, {{ .ReceiverName }}.UserPermissions(r))
-		if err != nil {
-			return httpio.NewEncoder(w).ClientMessage(ctx, err)
-		}
-
 		{{ if .Resource.IsScoped }}
 		customSession, err := customsession.DataFromCtx(ctx)
 		if err != nil {
 			return httpio.NewEncoder(w).ClientMessage(ctx, err)
 		}
+
+		q := r.URL.Query()
+		tenantFilter := fmt.Sprintf("{{ Camel $.TenantID }}:eq:%s", customSession.{{ $.TenantID }}.UUID)
+		if existingFilter := q.Get("filter"); existingFilter != "" {
+			tenantFilter = fmt.Sprintf("%s,%s", tenantFilter, existingFilter)
+		}
+		q.Set("filter", tenantFilter)
+		r.URL.RawQuery = q.Encode()
 		{{ end }}
 
-		res := {{ if .Resource.IsVirtual }}{{ .VirtualResourcesPackage }}{{ else }}{{ .ResourcePackage }}{{ end }}.New{{ .Resource.Name }}QueryFromQuerySet(querySet){{ if .Resource.IsScoped }}.Set{{ $.TenantID }}(customSession.{{ $.TenantID }}.UUID){{ end }}
+		querySet, err := decoder.Decode(r, {{ .ReceiverName }}.UserPermissions(r))
+		if err != nil {
+			return httpio.NewEncoder(w).ClientMessage(ctx, err)
+		}
+
+		res := {{ if .Resource.IsVirtual }}{{ .VirtualResourcesPackage }}{{ else }}{{ .ResourcePackage }}{{ end }}.New{{ .Resource.Name }}QueryFromQuerySet(querySet)
 
 		resp := response{}
 		for row, err := range res.List(ctx, {{ .ReceiverName }}.ResourceClient()) {
@@ -736,6 +744,13 @@ import (
 					return errors.Wrap(err, "decoder.DecodeOperation()")
 				}
 
+				{{- if $.Resource.IsScoped }}
+				customSession, err := customsession.DataFromCtx(ctx)
+				if err != nil {
+					return httpio.NewEncoder(w).ClientMessage(ctx, err)
+				}
+				{{- end }}
+
 				switch op.Type {
 				case resource.OperationCreate:
 				{{- if $PrimaryKeyIsGeneratedUUID }}
@@ -765,11 +780,25 @@ import (
 					{{- range $i, $field := .Resource.PrimaryKeys }}
 					id{{ $i }} := httpio.Param[{{ $field.Type }}](op.Req, "id{{ $i }}")
 					{{- end }}
+
+					{{- if $.Resource.IsScoped }}
+					if _, err := {{ .ResourcePackage }}.New{{ .Resource.Name }}Query().{{ range $i, $field := .Resource.PrimaryKeys }}Set{{ $field.Name }}(id{{ $i }}){{ end }}.Set{{ $.TenantID }}(customSession.{{ $.TenantID }}.UUID).Read(ctx, txn); err != nil {
+						return httpio.NewEncoder(w).ClientMessage(ctx, err)
+					}
+					{{- end }}
+
 					if err := {{ .ResourcePackage }}.New{{ .Resource.Name }}UpdatePatchFromPatchSet({{- range $i := .Resource.PrimaryKeys }}id{{ $i }}, {{ end }}patchSet).Buffer(ctx, txn, eventSource); err != nil {
 						return errors.Wrap(err, "{{ .ResourcePackage }}.{{ .Resource.Name }}UpdatePatch.Buffer()")
 					}
 				{{- else }}
 					id := httpio.Param[{{ $PrimaryKeyType }}](op.Req, "id")
+
+					{{- if $.Resource.IsScoped }}
+					if _, err := {{ .ResourcePackage }}.New{{ .Resource.Name }}Query().Set{{ $.Resource.PrimaryKey.Name }}(id).Set{{ $.TenantID }}(customSession.{{ $.TenantID }}.UUID).Read(ctx, txn); err != nil {
+						return httpio.NewEncoder(w).ClientMessage(ctx, err)
+					}
+					{{- end }}
+
 					if err := {{ .ResourcePackage }}.New{{ .Resource.Name }}UpdatePatchFromPatchSet(id, patchSet).Buffer(ctx, txn, eventSource); err != nil {
 						return errors.Wrap(err, "{{ .ResourcePackage }}.{{ .Resource.Name }}UpdatePatch.Buffer()")
 					}
@@ -779,11 +808,25 @@ import (
 					{{- range $i, $field := .Resource.PrimaryKeys }}
 						id{{ $i }} := httpio.Param[{{ $field.Type }}](op.Req, "id{{ $i }}")
 					{{- end }}
+
+					{{- if $.Resource.IsScoped }}
+					if _, err := {{ .ResourcePackage }}.New{{ .Resource.Name }}Query().{{ range $i, $field := .Resource.PrimaryKeys }}Set{{ $field.Name }}(id{{ $i }}){{ end }}.Set{{ $.TenantID }}(customSession.{{ $.TenantID }}.UUID).Read(ctx, txn); err != nil {
+						return httpio.NewEncoder(w).ClientMessage(ctx, err)
+					}
+					{{- end }}
+
 					if err := {{ .ResourcePackage }}.New{{ .Resource.Name }}DeletePatchFromPatchSet({{- range $i := .Resource.PrimaryKeys }}id{{ $i }}, {{ end }}patchSet).Buffer(ctx, txn, eventSource); err != nil {
 						return errors.Wrap(err, "{{ .ResourcePackage }}.{{ .Resource.Name }}DeletePatch.Buffer()")
 					}
 				{{- else }}
 					id := httpio.Param[{{ $PrimaryKeyType }}](op.Req, "id")
+
+					{{- if $.Resource.IsScoped }}
+					if _, err := {{ .ResourcePackage }}.New{{ .Resource.Name }}Query().Set{{ $.Resource.PrimaryKey.Name }}(id).Set{{ $.TenantID }}(customSession.{{ $.TenantID }}.UUID).Read(ctx, txn); err != nil {
+						return httpio.NewEncoder(w).ClientMessage(ctx, err)
+					}
+					{{- end }}
+
 					if err := {{ .ResourcePackage }}.New{{ .Resource.Name }}DeletePatchFromPatchSet(id, patchSet).Buffer(ctx, txn, eventSource); err != nil {
 						return errors.Wrap(err, "{{ .ResourcePackage }}.{{ .Resource.Name }}DeletePatch.Buffer()")
 					}
@@ -899,11 +942,25 @@ func ({{ .ReceiverName }} *{{ .ApplicationName }}) PatchResources() http.Handler
 							{{- range $i, $field := $resource.PrimaryKeys }}
 							id{{ $i }} := httpio.Param[{{ $field.Type }}](req, "id{{ $i }}")
 							{{- end }}
+
+							{{- if $.Resource.IsScoped }}
+							if _, err := {{ $resourcePackage }}.New{{ .Resource.Name }}Query().{{ range $i, $field := .Resource.PrimaryKeys }}Set{{ $field.Name }}(id{{ $i }}){{ end }}.Set{{ $.TenantID }}(customSession.{{ $.TenantID }}.UUID).Read(ctx, txn); err != nil {
+								return httpio.NewEncoder(w).ClientMessage(ctx, err)
+							}
+							{{- end }}
+
 							if err := {{ $resourcePackage }}.New{{ $resource.Name }}UpdatePatchFromPatchSet({{- range $i := $resource.PrimaryKeys }}id{{ $i }}, {{ end }}patchSet).Buffer(ctx, txn, eventSource); err != nil {
 								return errors.Wrap(handleError[{{ $resourcePackage }}.{{ $resource.Name }}](err), "{{ $resourcePackage }}.{{ $resource.Name }}UpdatePatch.Buffer()")
 							}
 							{{- else}}
 							id := httpio.Param[{{ $primaryKeyType }}](req, "id")
+
+							{{- if $.Resource.IsScoped }}
+							if _, err := {{ $resourcePackage }}.New{{ .Resource.Name }}Query().Set{{ $.Resource.PrimaryKey.Name }}(id).Set{{ $.TenantID }}(customSession.{{ $.TenantID }}.UUID).Read(ctx, txn); err != nil {
+								return httpio.NewEncoder(w).ClientMessage(ctx, err)
+							}
+							{{- end }}
+
 							if err := {{ $resourcePackage }}.New{{ $resource.Name }}UpdatePatchFromPatchSet(id, patchSet).Buffer(ctx, txn, eventSource); err != nil {
 								return errors.Wrap(handleError[{{ $resourcePackage }}.{{ $resource.Name }}](err), "{{ $resourcePackage }}.{{ $resource.Name }}UpdatePatch.Buffer()")
 							}
@@ -913,11 +970,25 @@ func ({{ .ReceiverName }} *{{ .ApplicationName }}) PatchResources() http.Handler
 							{{- range $i, $field := $resource.PrimaryKeys }}
 							id{{ $i }} := httpio.Param[{{ $field.Type }}](req, "id{{ $i }}")
 							{{- end }}
+
+							{{- if $.Resource.IsScoped }}
+							if _, err := {{ $resourcePackage }}.New{{ .Resource.Name }}Query().{{ range $i, $field := .Resource.PrimaryKeys }}Set{{ $field.Name }}(id{{ $i }}){{ end }}.Set{{ $.TenantID }}(customSession.{{ $.TenantID }}.UUID).Read(ctx, txn); err != nil {
+								return httpio.NewEncoder(w).ClientMessage(ctx, err)
+							}
+							{{- end }}
+
 							if err := {{ $resourcePackage }}.New{{ $resource.Name }}DeletePatchFromPatchSet({{- range $i := $resource.PrimaryKeys }}id{{ $i }}, {{ end }}patchSet).Buffer(ctx, txn, eventSource); err != nil {
 								return errors.Wrap(handleError[{{ $resourcePackage }}.{{ $resource.Name }}](err), "{{ $resourcePackage }}.{{ $resource.Name }}DeletePatch.Buffer()")
 							}
 							{{- else }}
 							id := httpio.Param[{{ $primaryKeyType }}](req, "id")
+
+							{{- if $.Resource.IsScoped }}
+							if _, err := {{ $resourcePackage }}.New{{ .Resource.Name }}Query().Set{{ $.Resource.PrimaryKey.Name }}(id).Set{{ $.TenantID }}(customSession.{{ $.TenantID }}.UUID).Read(ctx, txn); err != nil {
+								return httpio.NewEncoder(w).ClientMessage(ctx, err)
+							}
+							{{- end }}
+
 							if err := {{ $resourcePackage }}.New{{ $resource.Name }}DeletePatchFromPatchSet(id, patchSet).Buffer(ctx, txn, eventSource); err != nil {
 								return errors.Wrap(handleError[{{ $resourcePackage }}.{{ $resource.Name }}](err), "{{ $resourcePackage }}.{{ $resource.Name }}DeletePatch.Buffer()")
 							}

--- a/resource/generation/templates.go
+++ b/resource/generation/templates.go
@@ -1232,7 +1232,7 @@ const (
 {{- end }}
 
 type GeneratedHandlers interface {
-	{{- range $Struct, $Routes := .RoutesMap }}
+	{{- range $ResourceName, $Routes := .RoutesMap }}
 	{{- range $Routes }}
 	{{ .HandlerFunc }}() http.HandlerFunc
 	{{- end }}
@@ -1243,7 +1243,7 @@ type GeneratedHandlers interface {
 }
 
 func generatedRoutes(r chi.Router, h GeneratedHandlers) {
-{{- range $Struct, $Routes := .RoutesMap }}
+{{- range $ResourceName, $Routes := .RoutesMap }}
 	{{- range $route := $Routes }}
 	{{- if $route.SharedHandler }}
 	{{ Camel $route.HandlerFunc }}Handler := h.{{ $route.HandlerFunc }}()
@@ -1357,7 +1357,7 @@ func generatedRouterTests() []*generatedRouterTest {
 }
 
 func generatedExpectCalls(e *mock_router.MockHandlersMockRecorder, rec *callRecorder) {
-	{{ range $Struct, $Routes := .RoutesMap }}{{ range $Routes }}e.{{ .HandlerFunc }}().Times(1).Return(rec.RecordHandlerCall("{{ .HandlerFunc }}"))
+	{{ range $ResourceName, $Routes := .RoutesMap }}{{ range $Routes }}e.{{ .HandlerFunc }}().Times(1).Return(rec.RecordHandlerCall("{{ .HandlerFunc }}"))
 	{{ end }}{{- end -}}
 	{{- if eq .HasConsolidatedHandler true }}e.PatchResources().Times(1).Return(rec.RecordHandlerCall("PatchResources")){{ end -}}
 }`

--- a/resource/generation/templates.go
+++ b/resource/generation/templates.go
@@ -646,6 +646,13 @@ import (
 		ctx, span := ccc.StartTrace(r.Context())
 		defer span.End()
 
+	{{ if .Resource.IsScoped }}
+		customSession, err := customsession.DataFromCtx(ctx)
+		if err != nil {
+			return httpio.NewEncoder(w).ClientMessage(ctx, err)
+		}
+	{{ end }}
+
 	{{ if .Resource.HasCompoundPrimaryKey }}
 	{{- range $_, $field := .Resource.PrimaryKeys }}
 		{{ GoCamel $field.Name }} := httpio.Param[{{ $field.Type }}](r, router.{{ $.Resource.Name }}{{ $field.Name }})
@@ -663,6 +670,7 @@ import (
 	{{- else }}
 		res := {{ if .Resource.IsVirtual }}{{ .VirtualResourcesPackage }}{{ else }}{{ .ResourcePackage }}{{ end }}.New{{ .Resource.Name }}QueryFromQuerySet(querySet).Set{{ .Resource.PrimaryKey.Name }}(id)
 	{{- end }}
+	{{- if .Resource.IsScoped }}.Set{{ $.TenantID }}(customSession.{{ $.TenantID }}.UUID){{ end }}
 
 		row, err := res.Read(ctx, {{ .ReceiverName }}.ResourceClient())
 		if err != nil {

--- a/resource/generation/templates.go
+++ b/resource/generation/templates.go
@@ -60,7 +60,7 @@ func New{{ .Resource.Name }}QueryFromQuerySet(qSet *resource.QuerySet[{{ .Resour
 }
 
 {{ range $field := .Resource.Fields }}
-{{ if $field.IsUniqueIndex }}
+{{ if or $field.IsUniqueIndex (and $.Resource.IsScoped (eq $.TenantID $field.Name)) }}
 func (q *{{ $field.Parent.Name }}Query) Set{{ $field.Name }}(v {{ $field.ResolvedType }}) *{{ $field.Parent.Name }}Query {
 	q.qSet.SetKey("{{ $field.Name }}", v)
 
@@ -601,8 +601,15 @@ import (
 		if err != nil {
 			return httpio.NewEncoder(w).ClientMessage(ctx, err)
 		}
+		
+		{{ if .Resource.IsScoped }}
+		customSession, err := customsession.DataFromCtx(ctx)
+		if err != nil {
+			return httpio.NewEncoder(w).ClientMessage(ctx, err)
+		}
+		{{ end }}
 
-		res := {{ if .Resource.IsVirtual }}{{ .VirtualResourcesPackage }}{{ else }}{{ .ResourcePackage }}{{ end }}.New{{ .Resource.Name }}QueryFromQuerySet(querySet)
+		res := {{ if .Resource.IsVirtual }}{{ .VirtualResourcesPackage }}{{ else }}{{ .ResourcePackage }}{{ end }}.New{{ .Resource.Name }}QueryFromQuerySet(querySet){{ if .Resource.IsScoped }}.Set{{ $.TenantID }}(customSession.{{ $.TenantID }}.UUID){{ end }}
 
 		resp := response{}
 		for row, err := range res.List(ctx, {{ .ReceiverName }}.ResourceClient()) {

--- a/resource/generation/templates.go
+++ b/resource/generation/templates.go
@@ -76,14 +76,38 @@ func (q *{{ $field.Parent.Name }}Query) {{ $field.Name }}() {{ $field.ResolvedTy
 {{ end }}
 
 func (q *{{ .Resource.Name }}Query) Read(ctx context.Context, txn resource.ReadOnlyTransaction) (*{{ .Resource.Name }}, error) {
+	{{- if .Resource.IsScoped }}
+	if keyMap := q.qSet.KeySet().KeyMap(); len(keyMap) > 0 {
+		if _, ok := keyMap[accesstypes.Field("{{ .TenantID }}")]; !ok {
+			panic("{{ .Resource.Name }}Query KeySet does not include mandatory {{ .TenantID }}. Hint: set with .Set{{ .TenantID }}(...)")
+		}
+	}
+	{{ end -}}
+
 	return q.qSet.Read(ctx, txn)
 }
 
 func (q *{{ .Resource.Name }}Query) List(ctx context.Context, txn resource.ReadOnlyTransaction) iter.Seq2[*{{ .Resource.Name }}, error] {
+	{{- if .Resource.IsScoped }}
+	if keyMap := q.qSet.KeySet().KeyMap(); len(keyMap) > 0 {
+		if _, ok := keyMap[accesstypes.Field("{{ .TenantID }}")]; !ok {
+			panic("{{ .Resource.Name }}Query KeySet does not include mandatory {{ .TenantID }}. Hint: set with .Set{{ .TenantID }}(...)")
+		}
+	}
+	{{ end -}}
+
 	return q.qSet.List(ctx, txn)
 }
 
 func (q *{{ .Resource.Name }}Query) BatchList(ctx context.Context, client resource.Client, size int) iter.Seq[iter.Seq2[*{{ .Resource.Name }}, error]] {
+	{{- if .Resource.IsScoped }}
+	if keyMap := q.qSet.KeySet().KeyMap(); len(keyMap) > 0 {
+		if _, ok := keyMap[accesstypes.Field("{{ .TenantID }}")]; !ok {
+			panic("{{ .Resource.Name }}Query KeySet does not include mandatory {{ .TenantID }}. Hint: set with .Set{{ .TenantID }}(...)")
+		}
+	}
+	{{ end -}}
+
 	return q.qSet.BatchList(ctx, client, size)
 }
 
@@ -100,6 +124,11 @@ func (q *{{ .Resource.Name }}Query) Where(c {{ .Resource.Name }}QueryClause) *{{
 	if err := c.clause.Validate(); err != nil {
 		panic(err)
 	}
+	{{- if .Resource.IsScoped }}
+	if !c.clause.ContainsCondition(&resource.Condition{Field: "{{ .TenantID }}", Operator: "eq"}) {
+		panic("{{ .Resource.Name }}Query QueryClause does not contain mandatory {{ .TenantID }} equals condition. Hint: Add .{{ .TenantID }}.Equals(...)")
+	}
+	{{- end }}
 	q.qSet.SetWhereClause(c.clause)
 
 	return q

--- a/resource/generation/types.go
+++ b/resource/generation/types.go
@@ -181,7 +181,7 @@ type generatedRoute struct {
 	Method        string
 	Path          string
 	HandlerFunc   string
-	SharedHandler bool // whether the handler is shared between Patch and [Read or List] routes
+	SharedHandler bool // whether the handler is shared between Post and [Read or List] routes (Post is used for safely filtering on PII data)
 	HandlerType   HandlerType
 }
 

--- a/resource/generation/types.go
+++ b/resource/generation/types.go
@@ -361,6 +361,7 @@ type resourceInfo struct {
 	DefaultsUpdateType string
 	ValidateCreateType string
 	ValidateUpdateType string
+	IsScoped           bool
 }
 
 func (r *resourceInfo) HasNullBool() bool {
@@ -822,6 +823,7 @@ const (
 	validateCreateTypeKeyword string = "validateCreateType" // Specifies a type to call "Validate()" on for validating a resource on creation
 	validateUpdateTypeKeyword string = "validateUpdateType" // Specifies a type to call "Validate()" on for validating a resource on update
 	primarykeyKeyword         string = "primarykey"         // Designates a field as a primary key in a Computed Resource
+	unscopedKeyword           string = "unscoped"           // Excludes a struct from requiring a foreign key to a tenant table
 )
 
 func resourceKeywords() map[string]genlang.KeywordOpts {
@@ -837,5 +839,13 @@ func resourceKeywords() map[string]genlang.KeywordOpts {
 		validateCreateTypeKeyword: {genlang.ScanStruct: genlang.ArgsRequired | genlang.Exclusive},
 		validateUpdateTypeKeyword: {genlang.ScanStruct: genlang.ArgsRequired | genlang.Exclusive},
 		primarykeyKeyword:         {genlang.ScanField: genlang.NoArgs},
+		unscopedKeyword:           {genlang.ScanStruct: genlang.NoArgs | genlang.Exclusive},
 	}
+}
+
+// multitenantScope is a cute little tuple struct for declaring a resource as a tenant and
+// the field name that scoped resources should use to reference the tenant.
+type multitenantScope struct {
+	resourceName string
+	fieldName    string
 }

--- a/resource/generation/types.go
+++ b/resource/generation/types.go
@@ -181,7 +181,7 @@ type generatedRoute struct {
 	Method        string
 	Path          string
 	HandlerFunc   string
-	SharedHandler bool
+	SharedHandler bool // whether the handler is shared between Patch and [Read or List] routes
 	HandlerType   HandlerType
 }
 

--- a/resource/querybuilder.go
+++ b/resource/querybuilder.go
@@ -48,9 +48,13 @@ func (qc QueryClause) Validate() error {
 	return nil
 }
 
-// ContainsCondition traverses the [QueryClause] tree and returns true if an [ExpressioNode]
+// ContainsCondition traverses the [QueryClause] tree and returns true if an [ExpressionNode]
 // is a [ConditionNode] whose Field and Operator fields match that passed in [Condition].
 func (qc QueryClause) ContainsCondition(cond *Condition) bool {
+	if qc.tree == nil {
+		return false
+	}
+
 	return containsCondition(qc.tree, cond)
 }
 

--- a/resource/querybuilder.go
+++ b/resource/querybuilder.go
@@ -48,6 +48,29 @@ func (qc QueryClause) Validate() error {
 	return nil
 }
 
+// ContainsCondition traverses the [QueryClause] tree and returns true if an [ExpressioNode]
+// is a [ConditionNode] whose Field and Operator fields match that passed in [Condition].
+func (qc QueryClause) ContainsCondition(cond *Condition) bool {
+	return containsCondition(qc.tree, cond)
+}
+
+func containsCondition(root ExpressionNode, target *Condition) bool {
+	switch t := root.(type) {
+	case *GroupNode:
+		return containsCondition(t.Expression, target)
+	case *LogicalOpNode:
+		if containsCondition(t.Left, target) {
+			return true
+		}
+
+		return containsCondition(t.Right, target)
+	case *ConditionNode:
+		return t.Condition.Field == target.Field && t.Condition.Operator == target.Operator
+	default:
+		panic(fmt.Sprintf("containsCondition: unexpected ExpressionNode type %T", t))
+	}
+}
+
 // And starts a logical AND operation, returning a PartialQueryClause to which the right-hand side can be appended.
 func (qc QueryClause) And() PartialQueryClause {
 	return PartialQueryClause{

--- a/resource/querybuilder.go
+++ b/resource/querybuilder.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"fmt"
+	"strings"
 
 	stderr "errors"
 )
@@ -55,21 +56,21 @@ func (qc QueryClause) ContainsCondition(cond *Condition) bool {
 		return false
 	}
 
-	return containsCondition(qc.tree, cond)
+	return ContainsCondition(qc.tree, cond)
 }
 
-func containsCondition(root ExpressionNode, target *Condition) bool {
+func ContainsCondition(root ExpressionNode, target *Condition) bool {
 	switch t := root.(type) {
 	case *GroupNode:
-		return containsCondition(t.Expression, target)
+		return ContainsCondition(t.Expression, target)
 	case *LogicalOpNode:
-		if containsCondition(t.Left, target) {
+		if ContainsCondition(t.Left, target) {
 			return true
 		}
 
-		return containsCondition(t.Right, target)
+		return ContainsCondition(t.Right, target)
 	case *ConditionNode:
-		return t.Condition.Field == target.Field && t.Condition.Operator == target.Operator
+		return strings.EqualFold(t.Condition.Field, target.Field) && strings.EqualFold(t.Condition.Operator, target.Operator)
 	default:
 		panic(fmt.Sprintf("containsCondition: unexpected ExpressionNode type %T", t))
 	}

--- a/resource/querybuilder_test.go
+++ b/resource/querybuilder_test.go
@@ -521,12 +521,13 @@ func Test_containsCondition(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		tc := tt // capture range variable
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			for i, expect := range tt.expect {
-				if ok := tt.qc.ContainsCondition(&expect); !ok {
-					t.Errorf("%s: expected query clause to contain condition %d (field=%q, operator=%q)", tt.name, i, expect.Field, expect.Operator)
+			for i, expect := range tc.expect {
+				if ok := tc.qc.ContainsCondition(&expect); !ok {
+					t.Errorf("%s: expected query clause to contain condition %d (field=%q, operator=%q)", tc.name, i, expect.Field, expect.Operator)
 				}
 			}
 		})

--- a/resource/querybuilder_test.go
+++ b/resource/querybuilder_test.go
@@ -494,3 +494,41 @@ func TestQueryClause_Validate(t *testing.T) {
 		})
 	}
 }
+
+func Test_containsCondition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		qc     QueryClause
+		expect []Condition
+	}{
+		{
+			name: "happy path finds expected conditions",
+			qc: newTestQueryFilter().Name().Equal("A").Or().
+				Group(newTestQueryFilter().IndexedID().LessThanEq(1).And().NonIndexedField().NotEqual("foo")).expr,
+			expect: []Condition{
+				{
+					Field:    "Name",
+					Operator: eqStr,
+				},
+				{
+					Field:    "ID",
+					Operator: lteStr,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			for i, expect := range tt.expect {
+				if ok := tt.qc.ContainsCondition(&expect); !ok {
+					t.Errorf("%s: expected query clause to contain condition %d (field=%q, operator=%q)", tt.name, i, expect.Field, expect.Operator)
+				}
+			}
+		})
+	}
+}

--- a/resource/querybuilder_test.go
+++ b/resource/querybuilder_test.go
@@ -498,23 +498,61 @@ func TestQueryClause_Validate(t *testing.T) {
 func Test_containsCondition(t *testing.T) {
 	t.Parallel()
 
+	type args struct {
+		cond       Condition
+		isExpected bool
+	}
+
 	tests := []struct {
-		name   string
-		qc     QueryClause
-		expect []Condition
+		name string
+		qc   QueryClause
+		args []args
 	}{
 		{
 			name: "happy path finds expected conditions",
 			qc: newTestQueryFilter().Name().Equal("A").Or().
 				Group(newTestQueryFilter().IndexedID().LessThanEq(1).And().NonIndexedField().NotEqual("foo")).expr,
-			expect: []Condition{
+			args: []args{
 				{
-					Field:    "Name",
-					Operator: eqStr,
+					cond: Condition{
+						Field:    "Name",
+						Operator: eqStr,
+					},
+					isExpected: true,
 				},
 				{
-					Field:    "ID",
-					Operator: lteStr,
+					cond: Condition{
+						Field:    "ID",
+						Operator: lteStr,
+					},
+					isExpected: true,
+				},
+				{
+					cond: Condition{
+						Field:    "ID",
+						Operator: gteStr,
+					},
+					isExpected: false,
+				},
+			},
+		},
+		{
+			name: "does not find conditions that aren't there",
+			qc:   newTestQueryFilter().NonIndexedField().Equal("A").expr,
+			args: []args{
+				{
+					cond: Condition{
+						Field:    "Name",
+						Operator: eqStr,
+					},
+					isExpected: false,
+				},
+				{
+					cond: Condition{
+						Field:    "ID",
+						Operator: lteStr,
+					},
+					isExpected: false,
 				},
 			},
 		},
@@ -525,9 +563,11 @@ func Test_containsCondition(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			for i, expect := range tc.expect {
-				if ok := tc.qc.ContainsCondition(&expect); !ok {
-					t.Errorf("%s: expected query clause to contain condition %d (field=%q, operator=%q)", tc.name, i, expect.Field, expect.Operator)
+			for i, args := range tc.args {
+				if ok := tc.qc.ContainsCondition(&args.cond); !ok && ok != args.isExpected {
+					t.Errorf("%s: expected query clause to contain condition %d (field=%q, operator=%q)", tc.name, i, args.cond.Field, args.cond.Operator)
+				} else if ok && ok != args.isExpected {
+					t.Errorf("%s: expected query clause to not contain condition %d (field=%q, operator=%q) but it totally did", tc.name, i, args.cond.Field, args.cond.Operator)
 				}
 			}
 		})


### PR DESCRIPTION
- Adds `WithTenantScope` option to Resource Generator
  - `WithTenantScope` requires that resources reference a given tenant resource via foreign key with a designated field name
- Generated queryset instances for resources in an app with a tenant will panic if filters don't include the tenant in filters
- Resources that don't require scoping to a tenant can be excluded by adding the `@unscoped` annotation to the struct definition