### PR TITLE
fix: bump tracer and cache to Go 1.26.5

### DIFF
--- a/cache/go.mod
+++ b/cache/go.mod
@@ -1,6 +1,6 @@
 module github.com/cccteam/ccc/cache
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/fxamacker/cbor/v2 v2.9.2

--- a/tracer/go.mod
+++ b/tracer/go.mod
@@ -1,6 +1,6 @@
 module github.com/cccteam/ccc/tracer
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.31.0


### PR DESCRIPTION
## Why
`tracer` and `cache` were still on Go 1.26.4, which leaves them exposed to the currently reported standard-library vulnerabilities in this repo's vuln reporting.

## What changed
This updates only the module toolchain version in the two affected modules:
- `tracer/go.mod`: `go 1.26.4` -> `go 1.26.5`
- `cache/go.mod`: `go 1.26.4` -> `go 1.26.5`

## Notes
This is a targeted dependency/toolchain remediation PR with no application logic changes.