### PR TITLE
fix: Write generated Go files atomically to prevent stranded empty files

### DIFF
--- a/resource/.golangci.yml
+++ b/resource/.golangci.yml
@@ -102,6 +102,10 @@ linters:
         - style
     gocyclo:
       min-complexity: 25
+    gosec:
+      config:
+        # Generated source files are written world-readable, matching os.Create defaults
+        G306: '0644'
     godox:
       keywords:
         - TODO

--- a/resource/generation/client.go
+++ b/resource/generation/client.go
@@ -338,6 +338,27 @@ func (c *client) generateTemplateOutput(templateName, fileTemplate string, data 
 	return buf.Bytes(), nil
 }
 
+// writeFormattedGoFile renders a Go file template and formats the result fully in memory,
+// only writing destinationPath once the content is known good, so a template or format
+// error cannot leave behind an empty or partial generated file.
+func (c *client) writeFormattedGoFile(destinationPath, templateName, fileTemplate string, data any) error {
+	output, err := c.generateTemplateOutput(templateName, fileTemplate, data)
+	if err != nil {
+		return errors.Wrap(err, "generateTemplateOutput()")
+	}
+
+	formattedOutput, err := c.GoFormatBytes(destinationPath, output)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(destinationPath, formattedOutput, 0o644); err != nil {
+		return errors.Wrapf(err, "os.WriteFile(): file: %s", destinationPath)
+	}
+
+	return nil
+}
+
 func (c *client) retrieveDatabaseEnumValues(namedTypes []*parser.NamedType) (map[string][]*enumData, error) {
 	enumMap := make(map[string][]*enumData)
 	for _, namedType := range namedTypes {

--- a/resource/generation/computed.go
+++ b/resource/generation/computed.go
@@ -1,13 +1,10 @@
 package generation
 
 import (
-	"bytes"
 	"fmt"
 	"log"
-	"os"
 	"path/filepath"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/go-playground/errors/v5"
@@ -18,19 +15,7 @@ func (r *resourceGenerator) generateComputedResourceHandler(res *computedResourc
 	fileName := generatedGoFileName(strings.ToLower(caser.ToSnake(res.Name())))
 	destinationFilePath := filepath.Join(r.handler.Dir(), fileName)
 
-	file, err := os.Create(destinationFilePath)
-	if err != nil {
-		return errors.Wrap(err, "os.Create()")
-	}
-	defer file.Close()
-
-	tmpl, err := template.New(fmt.Sprintf("computedResourceHandlerTemplate:%q", res.Name())).Funcs(r.templateFuncs()).Parse(computedResourceHandlerTemplate)
-	if err != nil {
-		return errors.Wrap(err, "template.New().Parse()")
-	}
-
-	buf := bytes.NewBuffer(nil)
-	if err := tmpl.Execute(buf, computedHandlerData{
+	if err := r.writeFormattedGoFile(destinationFilePath, fmt.Sprintf("computedResourceHandlerTemplate:%q", res.Name()), computedResourceHandlerTemplate, computedHandlerData{
 		Source:              r.computed.Dir(),
 		LocalPackageImports: r.localPackageImports(),
 		Resource:            res,
@@ -39,16 +24,7 @@ func (r *resourceGenerator) generateComputedResourceHandler(res *computedResourc
 		ApplicationName:     r.applicationName,
 		ReceiverName:        r.receiverName,
 	}); err != nil {
-		return errors.Wrap(err, "tmpl.Execute()")
-	}
-
-	formattedBytes, err := r.GoFormatBytes(file.Name(), buf.Bytes())
-	if err != nil {
-		return err
-	}
-
-	if err := r.WriteBytesToFile(file, formattedBytes); err != nil {
-		return err
+		return errors.Wrap(err, "writeFormattedGoFile()")
 	}
 
 	log.Printf("Generated RPC handler file in %s: %s", time.Since(begin), destinationFilePath)

--- a/resource/generation/handler.go
+++ b/resource/generation/handler.go
@@ -4,11 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"os"
 	"path/filepath"
 	"strings"
-	"sync"
-	"text/template"
 	"time"
 
 	"github.com/go-playground/errors/v5"
@@ -23,62 +20,34 @@ func (r *resourceGenerator) runHandlerGeneration() error {
 		return errors.Wrap(err, "c.generateResourceInterfaces()")
 	}
 
-	var (
-		consolidatedResources []*resourceInfo
-		wg                    sync.WaitGroup
-
-		errChan = make(chan error)
-	)
-	for _, res := range r.resources {
-		wg.Add(1)
-		go func() {
-			if err := r.generateHandlers(res); err != nil {
-				errChan <- err
-			}
-			wg.Done()
-		}()
-
-		if res.IsConsolidated {
-			consolidatedResources = append(consolidatedResources, res)
-		}
+	if err := forEachGo(r.resources, r.generateHandlers); err != nil {
+		return err
 	}
 
 	if r.genRPCMethods {
+		rpcMethods := make([]*rpcMethodInfo, 0, len(r.rpcMethods))
 		for _, rpcMethod := range r.rpcMethods {
-			if rpcMethod.SuppressHandler {
-				continue
+			if !rpcMethod.SuppressHandler {
+				rpcMethods = append(rpcMethods, rpcMethod)
 			}
+		}
 
-			wg.Go(func() {
-				if err := r.generateRPCHandler(rpcMethod); err != nil {
-					errChan <- err
-				}
-			})
+		if err := forEachGo(rpcMethods, r.generateRPCHandler); err != nil {
+			return err
 		}
 	}
 
 	if r.genComputedResources {
-		for _, res := range r.computedResources {
-			wg.Go(func() {
-				if err := r.generateComputedResourceHandler(res); err != nil {
-					errChan <- err
-				}
-			})
+		if err := forEachGo(r.computedResources, r.generateComputedResourceHandler); err != nil {
+			return err
 		}
 	}
 
-	go func() {
-		wg.Wait()
-		close(errChan)
-	}()
-
-	var handlerErrors error
-	for e := range errChan {
-		handlerErrors = errors.Join(handlerErrors, e)
-	}
-
-	if handlerErrors != nil {
-		return errors.Wrap(handlerErrors, "runHandlerGeneration()")
+	var consolidatedResources []*resourceInfo
+	for _, res := range r.resources {
+		if res.IsConsolidated {
+			consolidatedResources = append(consolidatedResources, res)
+		}
 	}
 
 	if len(consolidatedResources) > 0 {
@@ -108,34 +77,13 @@ func (r *resourceGenerator) generateHandlers(res *resourceInfo) error {
 		fileName := generatedGoFileName(strings.ToLower(caser.ToSnake(r.pluralize(res.Name()))))
 		destinationFilePath := filepath.Join(r.handler.Dir(), fileName)
 
-		file, err := os.Create(destinationFilePath)
-		if err != nil {
-			return errors.Wrap(err, "os.Create()")
-		}
-		defer file.Close()
-
-		tmpl, err := template.New("handlers").Funcs(r.templateFuncs()).Parse(handlerHeaderTemplate)
-		if err != nil {
-			return errors.Wrap(err, "template.New().Parse()")
-		}
-
-		buf := bytes.NewBuffer(nil)
-		if err := tmpl.Execute(buf, handlersFileData{
+		if err := r.writeFormattedGoFile(destinationFilePath, "handlers", handlerHeaderTemplate, handlersFileData{
 			Source:              r.resource.Dir(),
 			LocalPackageImports: r.localPackageImports(),
 			Handlers:            string(bytes.Join(handlerData, []byte("\n\n"))),
 			Package:             r.handler.Package(),
 		}); err != nil {
-			return errors.Wrap(err, "tmpl.Execute()")
-		}
-
-		formattedBytes, err := r.GoFormatBytes(file.Name(), buf.Bytes())
-		if err != nil {
-			return err
-		}
-
-		if err := r.WriteBytesToFile(file, formattedBytes); err != nil {
-			return err
+			return errors.Wrap(err, "writeFormattedGoFile()")
 		}
 		log.Printf("Generated handler file in %s: %s", time.Since(begin), destinationFilePath)
 	}
@@ -148,19 +96,7 @@ func (r *resourceGenerator) generateConsolidatedPatchHandler(resources []*resour
 	fileName := generatedGoFileName(consolidatedHandlerOutputName)
 	destinationFilePath := filepath.Join(r.handler.Dir(), fileName)
 
-	file, err := os.Create(destinationFilePath)
-	if err != nil {
-		return errors.Wrap(err, "os.Create()")
-	}
-	defer file.Close()
-
-	tmpl, err := template.New("consolidatedPatchHandler").Funcs(r.templateFuncs()).Parse(consolidatedPatchTemplate)
-	if err != nil {
-		return errors.Wrap(err, "template.New().Parse()")
-	}
-
-	buf := bytes.NewBuffer(nil)
-	if err := tmpl.Execute(buf, consolidatedPatchData{
+	if err := r.writeFormattedGoFile(destinationFilePath, "consolidatedPatchHandler", consolidatedPatchTemplate, consolidatedPatchData{
 		Source:              r.resource.Dir(),
 		LocalPackageImports: r.localPackageImports(),
 		Resources:           resources,
@@ -169,16 +105,7 @@ func (r *resourceGenerator) generateConsolidatedPatchHandler(resources []*resour
 		ApplicationName:     r.applicationName,
 		ReceiverName:        r.receiverName,
 	}); err != nil {
-		return errors.Wrap(err, "tmpl.Execute()")
-	}
-
-	formattedBytes, err := r.GoFormatBytes(file.Name(), buf.Bytes())
-	if err != nil {
-		return err
-	}
-
-	if err := r.WriteBytesToFile(file, formattedBytes); err != nil {
-		return err
+		return errors.Wrap(err, "writeFormattedGoFile()")
 	}
 
 	log.Printf("Generated consolidated handler file in %s: %s", time.Since(begin), destinationFilePath)
@@ -187,23 +114,18 @@ func (r *resourceGenerator) generateConsolidatedPatchHandler(resources []*resour
 }
 
 func (r *resourceGenerator) handlerContent(handler HandlerType, res *resourceInfo) ([]byte, error) {
-	tmpl, err := template.New("handler").Funcs(r.templateFuncs()).Parse(handler.template())
-	if err != nil {
-		return nil, errors.Wrap(err, "template.New().Parse()")
-	}
-
-	buf := bytes.NewBuffer([]byte{})
-	if err := tmpl.Execute(buf, handlerContentData{
+	output, err := r.generateTemplateOutput("handler", handler.template(), handlerContentData{
 		ResourcePackage:         r.resource.Package(),
 		Resource:                res,
 		VirtualResourcesPackage: r.virtual.Package(),
 		ApplicationName:         r.applicationName,
 		ReceiverName:            r.receiverName,
-	}); err != nil {
-		return nil, errors.Wrap(err, "tmpl.Execute()")
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "generateTemplateOutput()")
 	}
 
-	return buf.Bytes(), nil
+	return output, nil
 }
 
 func (c *client) handlerName(structName string, handlerType HandlerType) string {

--- a/resource/generation/resource.go
+++ b/resource/generation/resource.go
@@ -3,7 +3,6 @@ package generation
 import (
 	"context"
 	"log"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -165,33 +164,17 @@ func (r *resourceGenerator) runResourcesGeneration() error {
 }
 
 func (r *resourceGenerator) generateResourceInterfaces() error {
-	output, err := r.generateTemplateOutput("resourcesInterfaceTemplate", resourcesInterfaceTemplate, resourceInterfacesData{
+	destinationFile := filepath.Join(r.handler.Dir(), generatedGoFileName(resourceInterfaceOutputName))
+
+	if err := r.writeFormattedGoFile(destinationFile, "resourcesInterfaceTemplate", resourcesInterfaceTemplate, resourceInterfacesData{
 		Source:                   r.resource.Dir(),
 		Package:                  r.handler.Package(),
 		ResourcesPackage:         r.resource.Package(),
 		ComputedResourcesPackage: r.computed.Package(),
 		Types:                    r.resources,
 		ComputedResourceTypes:    r.computedResources,
-	})
-	if err != nil {
-		return errors.Wrap(err, "generateTemplateOutput()")
-	}
-
-	destinationFile := filepath.Join(r.handler.Dir(), generatedGoFileName(resourceInterfaceOutputName))
-
-	file, err := os.Create(destinationFile)
-	if err != nil {
-		return errors.Wrap(err, "os.Create()")
-	}
-	defer file.Close()
-
-	output, err = r.GoFormatBytes(file.Name(), output)
-	if err != nil {
-		return err
-	}
-
-	if err := r.WriteBytesToFile(file, output); err != nil {
-		return err
+	}); err != nil {
+		return errors.Wrap(err, "writeFormattedGoFile()")
 	}
 
 	return nil
@@ -212,28 +195,12 @@ func (r *resourceGenerator) generateResources(res *resourceInfo) error {
 		destinationFilePath = filepath.Join(r.virtual.Dir(), fileName)
 	}
 
-	output, err := r.generateTemplateOutput("resourceFileTemplate", resourceFileTemplate, resourceFileData{
+	if err := r.writeFormattedGoFile(destinationFilePath, "resourceFileTemplate", resourceFileTemplate, resourceFileData{
 		Source:   r.resource.Dir(),
 		Package:  packageName,
 		Resource: res,
-	})
-	if err != nil {
-		return errors.Wrap(err, "generateTemplateOutput()")
-	}
-
-	file, err := os.Create(destinationFilePath)
-	if err != nil {
-		return errors.Wrap(err, "os.Create()")
-	}
-	defer file.Close()
-
-	output, err = r.GoFormatBytes(file.Name(), output)
-	if err != nil {
-		return err
-	}
-
-	if err := r.WriteBytesToFile(file, output); err != nil {
-		return err
+	}); err != nil {
+		return errors.Wrap(err, "writeFormattedGoFile()")
 	}
 
 	log.Printf("Generated resource file in %s: %v\n", time.Since(begin), destinationFilePath)
@@ -247,29 +214,15 @@ func (r *resourceGenerator) generateEnums(namedTypes []*parser.NamedType) error 
 		return err
 	}
 
-	output, err := r.generateTemplateOutput("resourceEnumsTemplate", resourceEnumsTemplate, resourceEnumsData{
+	destinationFile := filepath.Join(r.resource.Dir(), generatedGoFileName(resourceEnumsFileName))
+
+	if err := r.writeFormattedGoFile(destinationFile, "resourceEnumsTemplate", resourceEnumsTemplate, resourceEnumsData{
 		Source:     r.resource.Dir(),
 		Package:    r.resource.Package(),
 		NamedTypes: namedTypes,
 		EnumMap:    enumMap,
-	})
-	if err != nil {
-		return errors.Wrap(err, "generateTemplateOutput()")
-	}
-
-	file, err := os.Create(filepath.Join(r.resource.Dir(), generatedGoFileName(resourceEnumsFileName)))
-	if err != nil {
-		return errors.Wrap(err, "os.Create()")
-	}
-	defer file.Close()
-
-	output, err = r.GoFormatBytes(file.Name(), output)
-	if err != nil {
-		return err
-	}
-
-	if err := r.WriteBytesToFile(file, output); err != nil {
-		return err
+	}); err != nil {
+		return errors.Wrap(err, "writeFormattedGoFile()")
 	}
 
 	return nil

--- a/resource/generation/router.go
+++ b/resource/generation/router.go
@@ -1,13 +1,10 @@
 package generation
 
 import (
-	"bytes"
 	"fmt"
 	"log"
-	"os"
 	"path/filepath"
 	"slices"
-	"text/template"
 	"time"
 
 	"github.com/ettle/strcase"
@@ -137,19 +134,7 @@ func (r *resourceGenerator) runRouteGeneration() error {
 }
 
 func (r *resourceGenerator) writeGeneratedRouterFile(destinationFile, templateContent string, resources, constResources []*resourceInfo, computedResources, constComputedResources []*computedResource, generatedRoutes map[string][]generatedRoute, hasConsolidatedHandlers bool) error {
-	file, err := os.Create(destinationFile)
-	if err != nil {
-		return errors.Wrap(err, "os.Create()")
-	}
-	defer file.Close()
-
-	tmpl, err := template.New(filepath.Base(destinationFile)).Funcs(r.templateFuncs()).Parse(templateContent)
-	if err != nil {
-		return errors.Wrap(err, "template.New().Parse()")
-	}
-
-	buf := bytes.NewBuffer([]byte{})
-	if err := tmpl.Execute(buf, routerFileData{
+	if err := r.writeFormattedGoFile(destinationFile, filepath.Base(destinationFile), templateContent, routerFileData{
 		Source:                 r.resource.Dir(),
 		Package:                r.router.Package(),
 		LocalPackageImports:    r.localPackageImports(),
@@ -162,16 +147,7 @@ func (r *resourceGenerator) writeGeneratedRouterFile(destinationFile, templateCo
 		RoutePrefix:            r.routePrefix,
 		ConsolidatedRoute:      r.ConsolidatedRoute,
 	}); err != nil {
-		return errors.Wrap(err, "tmpl.Execute()")
-	}
-
-	formattedBytes, err := r.GoFormatBytes(file.Name(), buf.Bytes())
-	if err != nil {
-		return err
-	}
-
-	if err := r.WriteBytesToFile(file, formattedBytes); err != nil {
-		return err
+		return errors.Wrap(err, "writeFormattedGoFile()")
 	}
 
 	return nil

--- a/resource/generation/rpc.go
+++ b/resource/generation/rpc.go
@@ -1,13 +1,10 @@
 package generation
 
 import (
-	"bytes"
 	"fmt"
 	"log"
-	"os"
 	"path/filepath"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/go-playground/errors/v5"
@@ -37,33 +34,12 @@ func (r *resourceGenerator) generateRPCMethod(rpc *rpcMethodInfo) error {
 	fileName := generatedGoFileName(strings.ToLower(caser.ToSnake(rpc.Name())))
 	destinationFilePath := filepath.Join(r.rpc.Dir(), fileName)
 
-	file, err := os.Create(destinationFilePath)
-	if err != nil {
-		return errors.Wrap(err, "os.Create()")
-	}
-	defer file.Close()
-
-	tmpl, err := template.New(fmt.Sprintf("rpcFileTemplate:%q", rpc.Name())).Funcs(r.templateFuncs()).Parse(rpcFileTemplate)
-	if err != nil {
-		return errors.Wrap(err, "template.New().Parse()")
-	}
-
-	buf := bytes.NewBuffer(nil)
-	if err := tmpl.Execute(buf, rpcFileData{
+	if err := r.writeFormattedGoFile(destinationFilePath, fmt.Sprintf("rpcFileTemplate:%q", rpc.Name()), rpcFileTemplate, rpcFileData{
 		Source:    r.rpc.Dir(),
 		Package:   r.rpc.Package(),
 		RPCMethod: rpc,
 	}); err != nil {
-		return errors.Wrap(err, "tmpl.Execute()")
-	}
-
-	formattedBytes, err := r.GoFormatBytes(file.Name(), buf.Bytes())
-	if err != nil {
-		return err
-	}
-
-	if err := r.WriteBytesToFile(file, formattedBytes); err != nil {
-		return err
+		return errors.Wrap(err, "writeFormattedGoFile()")
 	}
 
 	return nil
@@ -74,19 +50,7 @@ func (r *resourceGenerator) generateRPCHandler(rpcMethod *rpcMethodInfo) error {
 	fileName := generatedGoFileName(strings.ToLower(caser.ToSnake(rpcMethod.Name())))
 	destinationFilePath := filepath.Join(r.handler.Dir(), fileName)
 
-	file, err := os.Create(destinationFilePath)
-	if err != nil {
-		return errors.Wrap(err, "os.Create()")
-	}
-	defer file.Close()
-
-	tmpl, err := template.New(fmt.Sprintf("rcpHandlerTemplate:%q", rpcMethod.Name())).Funcs(r.templateFuncs()).Parse(rpcHandlerTemplate)
-	if err != nil {
-		return errors.Wrap(err, "template.New().Parse()")
-	}
-
-	buf := bytes.NewBuffer(nil)
-	if err := tmpl.Execute(buf, rpcHandlerData{
+	if err := r.writeFormattedGoFile(destinationFilePath, fmt.Sprintf("rcpHandlerTemplate:%q", rpcMethod.Name()), rpcHandlerTemplate, rpcHandlerData{
 		Source:              r.rpc.Dir(),
 		LocalPackageImports: r.localPackageImports(),
 		RPCMethod:           rpcMethod,
@@ -94,16 +58,7 @@ func (r *resourceGenerator) generateRPCHandler(rpcMethod *rpcMethodInfo) error {
 		ApplicationName:     r.applicationName,
 		ReceiverName:        r.receiverName,
 	}); err != nil {
-		return errors.Wrap(err, "tmpl.Execute()")
-	}
-
-	formattedBytes, err := r.GoFormatBytes(file.Name(), buf.Bytes())
-	if err != nil {
-		return err
-	}
-
-	if err := r.WriteBytesToFile(file, formattedBytes); err != nil {
-		return err
+		return errors.Wrap(err, "writeFormattedGoFile()")
 	}
 
 	log.Printf("Generated RPC handler file in %s: %s", time.Since(begin), destinationFilePath)
@@ -112,30 +67,14 @@ func (r *resourceGenerator) generateRPCHandler(rpcMethod *rpcMethodInfo) error {
 }
 
 func (r *resourceGenerator) generateRPCInterfaces() error {
-	output, err := r.generateTemplateOutput("rpcInterfacesTemplate", rpcInterfacesTemplate, rpcInterfacesData{
+	destinationFile := filepath.Join(".", r.rpc.Dir(), generatedGoFileName("rpc_iface"))
+
+	if err := r.writeFormattedGoFile(destinationFile, "rpcInterfacesTemplate", rpcInterfacesTemplate, rpcInterfacesData{
 		Source:  r.rpc.Dir(),
 		Package: r.rpc.Package(),
 		Types:   r.rpcMethods,
-	})
-	if err != nil {
-		return errors.Wrap(err, "generateTemplateOutput()")
-	}
-
-	destinationFile := filepath.Join(".", r.rpc.Dir(), generatedGoFileName("rpc_iface"))
-
-	file, err := os.Create(destinationFile)
-	if err != nil {
-		return errors.Wrap(err, "os.Create()")
-	}
-	defer file.Close()
-
-	output, err = r.GoFormatBytes(file.Name(), output)
-	if err != nil {
-		return err
-	}
-
-	if err := r.WriteBytesToFile(file, output); err != nil {
-		return err
+	}); err != nil {
+		return errors.Wrap(err, "writeFormattedGoFile()")
 	}
 
 	return nil


### PR DESCRIPTION
Extract a shared writeFormattedGoFile helper that renders and formats
generated Go source fully in memory, only writing the destination file
once the content is known good. Previously all nine generation sites
ran os.Create before executing the template, so any template or format
error stranded a zero-byte zz_gen_*.go that broke the consuming package.

Also replace the hand-rolled WaitGroup+errChan block in
runHandlerGeneration with the existing forEachGo helper, and route
handlerContent through generateTemplateOutput. Generated output is
byte-for-byte unchanged;