### PR TITLE
fix: Replace route string sniffing with structured route metadata

### DIFF
--- a/resource/generation/client.go
+++ b/resource/generation/client.go
@@ -255,61 +255,6 @@ func (c *client) templateFuncs() map[string]any {
 		"Add":                          func(a, b int) int { return a + b },
 		"FormatResourceInterfaceTypes": c.formatResourceInterfaceTypes,
 		"FormatRPCInterfaceTypes":      formatRPCInterfaceTypes,
-		"DetermineTestURL": func(resource resourceInfo, routePrefix string, route generatedRoute) string {
-			if !resource.IsVirtual &&
-				strings.EqualFold(route.Method, "get") &&
-				(strings.Contains(route.Path, fmt.Sprintf("{%sID}", strcase.ToGoCamel(resource.Name()))) || strings.Contains(route.Path, resource.PrimaryKey().Name())) {
-				if resource.HasCompoundPrimaryKey() {
-					url := fmt.Sprintf("/%s/%s", routePrefix, caser.ToKebab(c.pluralize(resource.Name())))
-
-					for _, key := range resource.PrimaryKeys() {
-						url += fmt.Sprintf("/test%s%s", caser.ToPascal(resource.Name()), key.Name())
-					}
-
-					return url
-				}
-
-				return fmt.Sprintf("/%s/%s/%s",
-					routePrefix,
-					caser.ToKebab(c.pluralize(resource.Name())),
-					strcase.ToGoCamel(fmt.Sprintf("test%sID", caser.ToPascal(resource.Name()))),
-				)
-			}
-
-			return route.Path
-		},
-		"DetermineParameters": func(resource resourceInfo, route generatedRoute) string {
-			if !resource.IsVirtual &&
-				strings.EqualFold(route.Method, "get") &&
-				(strings.Contains(route.Path, fmt.Sprintf("{%sID}", strcase.ToGoCamel(resource.Name()))) || strings.Contains(route.Path, resource.PrimaryKey().Name())) {
-				if resource.HasCompoundPrimaryKey() {
-					params := "map[string]string{"
-					for _, key := range resource.PrimaryKeys() {
-						params += fmt.Sprintf(`"%[1]s%[3]s": "test%[2]s%[3]s", `, strcase.ToGoCamel(resource.Name()), caser.ToPascal(resource.Name()), key.Name())
-					}
-
-					params += "}"
-
-					return params
-				}
-
-				return fmt.Sprintf(`map[string]string{%q: %q}`, strcase.ToGoCamel(resource.Name()+"ID"), strcase.ToGoCamel(fmt.Sprintf("test%sID", caser.ToPascal(resource.Name()))))
-			}
-
-			return "map[string]string{}"
-		},
-		"MethodToHttpConst": func(method string) (string, error) {
-			switch method {
-			case "GET":
-				return "http.MethodGet", nil
-			case "POST":
-				return "http.MethodPost", nil
-			case "PATCH":
-				return "http.MethodPatch", nil
-			default:
-				return "", errors.Newf("MethodToHttpConst: unknown method: %s", method)
-			}
-		},
 		"PrivateType": func(s string) string {
 			r, runeWidth := utf8.DecodeRuneInString(s)
 			lowerFirst := strings.ToLower(string(r))

--- a/resource/generation/router.go
+++ b/resource/generation/router.go
@@ -3,6 +3,7 @@ package generation
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"path/filepath"
 	"slices"
 	"time"
@@ -19,8 +20,8 @@ func (r *resourceGenerator) runRouteGeneration() error {
 
 	var hasConsolidatedHandlers bool
 	constResources := make([]*resourceInfo, 0, len(r.resources))
-	resources := make([]*resourceInfo, 0, len(r.resources))
-	generatedRoutesMap := make(map[string][]generatedRoute)
+	routerTestRoutes := make([]*generatedRoute, 0, len(r.resources)+len(r.computedResources))
+	generatedRoutesMap := make(map[string][]*generatedRoute)
 	for _, res := range r.resources {
 		handlerTypes := resourceEndpoints(res)
 
@@ -36,70 +37,78 @@ func (r *resourceGenerator) runRouteGeneration() error {
 			hasConsolidatedHandlers = true
 		}
 
-		if len(handlerTypes) > 0 {
-			resources = append(resources, res)
-		}
-
 		for _, ht := range handlerTypes {
-			path := fmt.Sprintf("/%s/%s", r.routePrefix, strcase.ToKebab(r.pluralize(res.Name())))
+			basePath := fmt.Sprintf("/%s/%s", r.routePrefix, strcase.ToKebab(r.pluralize(res.Name())))
+			route := &generatedRoute{
+				Method:      ht.method(),
+				Path:        basePath,
+				HandlerFunc: r.handlerName(res.Name(), ht),
+				HandlerType: ht,
+				TestURL:     basePath,
+			}
 			if ht == ReadHandler {
 				if res.HasCompoundPrimaryKey() {
+					var pkNames []string
 					for _, field := range res.PrimaryKeys() {
-						path += fmt.Sprintf("/{%s}", strcase.ToGoCamel(res.Name()+field.Name()))
+						pkNames = append(pkNames, field.Name())
 					}
+					route.TestParams = readRouteTestParams(res.Name(), pkNames)
 				} else {
-					path += fmt.Sprintf("/{%s}", strcase.ToGoCamel(res.Name()+"ID"))
+					route.TestParams = []routeTestParam{{
+						Key:   strcase.ToGoCamel(res.Name() + "ID"),
+						Value: strcase.ToGoCamel(fmt.Sprintf("test%sID", caser.ToPascal(res.Name()))),
+					}}
 				}
+				route.appendParamsToPaths()
 			}
 
-			generatedRoutesMap[res.Name()] = append(generatedRoutesMap[res.Name()], generatedRoute{
-				Method:        ht.method(),
-				Path:          path,
-				HandlerFunc:   r.handlerName(res.Name(), ht),
-				SharedHandler: ht == ReadHandler || ht == ListHandler,
-				HandlerType:   ht,
-			})
+			generatedRoutesMap[res.Name()] = append(generatedRoutesMap[res.Name()], route)
+			routerTestRoutes = append(routerTestRoutes, route)
 		}
 	}
 
 	constComputedResources := make([]*computedResource, 0, len(r.computedResources))
-	computedResources := make([]*computedResource, 0, len(r.computedResources))
 	for _, res := range r.computedResources {
-		if !res.SuppressListHandler || !res.SuppressReadHandler {
-			computedResources = append(computedResources, res)
-			if !res.SuppressReadHandler {
-				constComputedResources = append(constComputedResources, res)
-			}
+		if !res.SuppressReadHandler {
+			constComputedResources = append(constComputedResources, res)
 		}
 
 		if res.RoutingDisabled() {
 			continue
 		}
 
-		path := fmt.Sprintf("/%s/%s", r.routePrefix, strcase.ToKebab(r.pluralize(res.Name())))
+		basePath := fmt.Sprintf("/%s/%s", r.routePrefix, strcase.ToKebab(r.pluralize(res.Name())))
 		if !res.SuppressReadHandler {
-			var pathKeys string
+			var pkNames []string
 			for _, field := range res.PrimaryKeys() {
-				pathKeys += fmt.Sprintf("/{%s}", strcase.ToGoCamel(res.Name()+field.Name()))
+				pkNames = append(pkNames, field.Name())
 			}
 
-			generatedRoutesMap[res.Name()] = append(generatedRoutesMap[res.Name()], generatedRoute{
-				Method:        ReadHandler.method(),
-				Path:          path + pathKeys,
-				HandlerFunc:   r.handlerName(res.Name(), ReadHandler),
-				SharedHandler: true,
-				HandlerType:   ReadHandler,
-			})
+			route := &generatedRoute{
+				Method:      ReadHandler.method(),
+				Path:        basePath,
+				HandlerFunc: r.handlerName(res.Name(), ReadHandler),
+				HandlerType: ReadHandler,
+				TestURL:     basePath,
+				TestParams:  readRouteTestParams(res.Name(), pkNames),
+			}
+			route.appendParamsToPaths()
+
+			generatedRoutesMap[res.Name()] = append(generatedRoutesMap[res.Name()], route)
+			routerTestRoutes = append(routerTestRoutes, route)
 		}
 
 		if !res.SuppressListHandler {
-			generatedRoutesMap[res.Name()] = append(generatedRoutesMap[res.Name()], generatedRoute{
-				Method:        ListHandler.method(),
-				Path:          path,
-				HandlerFunc:   r.handlerName(res.Name(), ListHandler),
-				SharedHandler: true,
-				HandlerType:   ListHandler,
-			})
+			route := &generatedRoute{
+				Method:      ListHandler.method(),
+				Path:        basePath,
+				HandlerFunc: r.handlerName(res.Name(), ListHandler),
+				HandlerType: ListHandler,
+				TestURL:     basePath,
+			}
+
+			generatedRoutesMap[res.Name()] = append(generatedRoutesMap[res.Name()], route)
+			routerTestRoutes = append(routerTestRoutes, route)
 		}
 	}
 
@@ -109,46 +118,53 @@ func (r *resourceGenerator) runRouteGeneration() error {
 				continue
 			}
 
-			generatedRoutesMap[rpcStruct.Name()] = []generatedRoute{{
-				Method:      "POST",
+			generatedRoutesMap[rpcStruct.Name()] = []*generatedRoute{{
+				Method:      http.MethodPost,
 				Path:        fmt.Sprintf("/%s/%s", r.routePrefix, strcase.ToKebab(rpcStruct.Name())),
 				HandlerFunc: rpcStruct.Name(),
 			}}
 		}
 	}
 
+	data := routerFileData{
+		Source:                 r.resource.Dir(),
+		Package:                r.router.Package(),
+		LocalPackageImports:    r.localPackageImports(),
+		RoutesMap:              generatedRoutesMap,
+		ConstResources:         constResources,
+		ConstComputedResources: constComputedResources,
+		RouterTestRoutes:       routerTestRoutes,
+		HasConsolidatedHandler: hasConsolidatedHandlers,
+		RoutePrefix:            r.routePrefix,
+		ConsolidatedRoute:      r.ConsolidatedRoute,
+	}
+
 	routesDestination := filepath.Join(r.router.Dir(), generatedGoFileName(routesOutputName))
-	if err := r.writeGeneratedRouterFile(routesDestination, routesTemplate, resources, constResources, computedResources, constComputedResources, generatedRoutesMap, hasConsolidatedHandlers); err != nil {
-		return errors.Wrap(err, "c.writeRoutes()")
+	if err := r.writeFormattedGoFile(routesDestination, "routesTemplate", routesTemplate, data); err != nil {
+		return errors.Wrap(err, "writeFormattedGoFile()")
 	}
 	log.Printf("Generated routes file in %s: %s\n", time.Since(begin), routesDestination)
 
 	routerTestsDestination := filepath.Join(r.router.Dir(), generatedGoFileName(routerTestOutputName))
 	begin = time.Now()
-	if err := r.writeGeneratedRouterFile(routerTestsDestination, routerTestTemplate, resources, constResources, computedResources, constComputedResources, generatedRoutesMap, hasConsolidatedHandlers); err != nil {
-		return errors.Wrap(err, "c.writeRouterTests()")
+	if err := r.writeFormattedGoFile(routerTestsDestination, "routerTestTemplate", routerTestTemplate, data); err != nil {
+		return errors.Wrap(err, "writeFormattedGoFile()")
 	}
 	log.Printf("Generated router tests file in %s: %s\n", time.Since(begin), routerTestsDestination)
 
 	return nil
 }
 
-func (r *resourceGenerator) writeGeneratedRouterFile(destinationFile, templateContent string, resources, constResources []*resourceInfo, computedResources, constComputedResources []*computedResource, generatedRoutes map[string][]generatedRoute, hasConsolidatedHandlers bool) error {
-	if err := r.writeFormattedGoFile(destinationFile, filepath.Base(destinationFile), templateContent, routerFileData{
-		Source:                 r.resource.Dir(),
-		Package:                r.router.Package(),
-		LocalPackageImports:    r.localPackageImports(),
-		RoutesMap:              generatedRoutes,
-		ConstResources:         constResources,
-		Resources:              resources,
-		ComputedResources:      computedResources,
-		ConstComputedResources: constComputedResources,
-		HasConsolidatedHandler: hasConsolidatedHandlers,
-		RoutePrefix:            r.routePrefix,
-		ConsolidatedRoute:      r.ConsolidatedRoute,
-	}); err != nil {
-		return errors.Wrap(err, "writeFormattedGoFile()")
+// readRouteTestParams returns one route parameter per primary-key field for
+// addressing a read route in the generated router tests.
+func readRouteTestParams(resourceName string, pkNames []string) []routeTestParam {
+	params := make([]routeTestParam, 0, len(pkNames))
+	for _, pk := range pkNames {
+		params = append(params, routeTestParam{
+			Key:   strcase.ToGoCamel(resourceName + pk),
+			Value: fmt.Sprintf("test%s%s", caser.ToPascal(resourceName), pk),
+		})
 	}
 
-	return nil
+	return params
 }

--- a/resource/generation/router_test.go
+++ b/resource/generation/router_test.go
@@ -1,0 +1,51 @@
+package generation
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_readRouteTestParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		resourceName string
+		pkNames      []string
+		want         []routeTestParam
+	}{
+		{
+			name:         "single primary key",
+			resourceName: "Widget",
+			pkNames:      []string{"ID"},
+			want: []routeTestParam{
+				{Key: "widgetID", Value: "testWidgetID"},
+			},
+		},
+		{
+			name:         "compound primary key",
+			resourceName: "WidgetOrder",
+			pkNames:      []string{"WidgetID", "OrderID"},
+			want: []routeTestParam{
+				{Key: "widgetOrderWidgetID", Value: "testWidgetOrderWidgetID"},
+				{Key: "widgetOrderOrderID", Value: "testWidgetOrderOrderID"},
+			},
+		},
+		{
+			name:         "no primary keys",
+			resourceName: "Widget",
+			pkNames:      nil,
+			want:         []routeTestParam{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := readRouteTestParams(tt.resourceName, tt.pkNames)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("readRouteTestParams() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/resource/generation/templatedata.go
+++ b/resource/generation/templatedata.go
@@ -70,11 +70,10 @@ type routerFileData struct {
 	Source                 string
 	Package                string
 	LocalPackageImports    string
-	RoutesMap              map[string][]generatedRoute
+	RoutesMap              map[string][]*generatedRoute
 	ConstResources         []*resourceInfo
-	Resources              []*resourceInfo
-	ComputedResources      []*computedResource
 	ConstComputedResources []*computedResource
+	RouterTestRoutes       []*generatedRoute
 	HasConsolidatedHandler bool
 	RoutePrefix            string
 	ConsolidatedRoute      string

--- a/resource/generation/templates.go
+++ b/resource/generation/templates.go
@@ -1273,47 +1273,15 @@ func generatedRouteParameters() []string {
 	return keys
 }
 
-{{ $routePrefix := .RoutePrefix -}}
 func generatedRouterTests() []*generatedRouterTest {
 	routerTests := []*generatedRouterTest {
-		{{- range $resource := .Resources }}
-		{{- range $route := (index $.RoutesMap $resource.Name) }}
+		{{- range $route := .RouterTestRoutes }}
+		{{- range $method := $route.TestMethods }}
 		{
-			url: "{{ DetermineTestURL $resource $routePrefix $route }}", method: {{ MethodToHttpConst $route.Method }},
+			url: "{{ $route.TestURL }}", method: {{ $method }},
 			handlerFunc: "{{ $route.HandlerFunc }}",
-			parameters: {{ DetermineParameters $resource $route }},
+			parameters: map[string]string{ {{- range $param := $route.TestParams }}"{{ $param.Key }}": "{{ $param.Value }}", {{ end -}} },
 		},
-		{{- if $route.SharedHandler }}
-		{
-			url: "{{ DetermineTestURL $resource $routePrefix $route }}", method: http.MethodPost,
-			handlerFunc: "{{ $route.HandlerFunc }}",
-			parameters: {{ DetermineParameters $resource $route }},
-		},
-		{{- end }}
-		{{- end }}
-		{{- end }}
-		{{- range $resource := .ComputedResources }}
-		{{- range $route := (index $.RoutesMap $resource.Name) }}
-		{
-			url: "/{{ $routePrefix }}/{{ Kebab (Pluralize $resource.Name) }}{{ if eq $route.HandlerType "readHandler" }}{{ range $_, $field := $resource.PrimaryKeys }}/test{{ Pascal $resource.Name }}{{ $field.Name }}{{ end }}{{ end }}", method: {{ MethodToHttpConst $route.Method }},
-			handlerFunc: "{{ $route.HandlerFunc }}",
-			parameters: map[string]string{
-			{{- range $_, $field := $resource.PrimaryKeys }}{{ if eq $route.HandlerType "readHandler" -}}
-			"{{ GoCamel $resource.Name }}{{ $field.Name }}": "test{{ Pascal $resource.Name }}{{ $field.Name }}",
-			{{- end }}{{ end -}}
-			},
-		},
-		{{- if $route.SharedHandler }}
-		{
-			url: "/{{ $routePrefix }}/{{ Kebab (Pluralize $resource.Name) }}{{ if eq $route.HandlerType "readHandler" }}{{ range $_, $field := $resource.PrimaryKeys }}/test{{ Pascal $resource.Name }}{{ $field.Name }}{{ end }}{{ end }}", method: http.MethodPost,
-			handlerFunc: "{{ $route.HandlerFunc }}",
-			parameters: map[string]string{
-			{{- range $_, $field := $resource.PrimaryKeys }}{{ if eq $route.HandlerType "readHandler" -}}
-			"{{ GoCamel $resource.Name }}{{ $field.Name }}": "test{{ Pascal $resource.Name }}{{ $field.Name }}",
-			{{- end }}{{ end -}}
-			},
-		},
-		{{- end }}
 		{{- end }}
 		{{- end }}
 		{{- if .HasConsolidatedHandler }}

--- a/resource/generation/types.go
+++ b/resource/generation/types.go
@@ -3,6 +3,7 @@ package generation
 import (
 	"fmt"
 	"iter"
+	"net/http"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -129,12 +130,18 @@ func (h HandlerType) template() string {
 func (h HandlerType) method() string {
 	switch h {
 	case ReadHandler, ListHandler:
-		return "GET"
+		return http.MethodGet
 	case PatchHandler:
-		return "PATCH"
+		return http.MethodPatch
 	default:
 		panic(fmt.Sprintf("Method(): unknown handler type: %s", h))
 	}
+}
+
+// httpMethodConstant returns the net/http constant name for an http method
+// (e.g. "GET" -> "http.MethodGet").
+func httpMethodConstant(method string) string {
+	return "http.Method" + strcase.ToPascal(method)
 }
 
 type patchType string
@@ -216,11 +223,46 @@ type columnMeta struct {
 }
 
 type generatedRoute struct {
-	Method        string
-	Path          string
-	HandlerFunc   string
-	SharedHandler bool
-	HandlerType   HandlerType
+	Method      string
+	Path        string
+	HandlerFunc string
+	HandlerType HandlerType
+	// TestURL is Path with each {param} placeholder replaced by its routeTestParam value.
+	TestURL    string
+	TestParams []routeTestParam
+}
+
+// SharedHandler reports whether the route's handler is additionally registered
+// for POST requests at the same path (read and list handlers accept POST bodies).
+func (g *generatedRoute) SharedHandler() bool {
+	return g.HandlerType == ReadHandler || g.HandlerType == ListHandler
+}
+
+// appendParamsToPaths appends each test parameter to the route's paths: the
+// {param} placeholder onto Path and the test value onto TestURL.
+func (g *generatedRoute) appendParamsToPaths() {
+	for _, p := range g.TestParams {
+		g.Path += fmt.Sprintf("/{%s}", p.Key)
+		g.TestURL += "/" + p.Value
+	}
+}
+
+// TestMethods returns the net/http method constant names the generated router
+// tests exercise for this route.
+func (g *generatedRoute) TestMethods() []string {
+	methods := []string{httpMethodConstant(g.Method)}
+	if g.SharedHandler() {
+		methods = append(methods, httpMethodConstant(http.MethodPost))
+	}
+
+	return methods
+}
+
+// routeTestParam is a single route parameter and the value the generated router
+// tests pass for it. Key matches the {param} placeholder in the route path.
+type routeTestParam struct {
+	Key   string
+	Value string
 }
 
 type rpcMethodInfo struct {

--- a/resource/generation/types_test.go
+++ b/resource/generation/types_test.go
@@ -2,6 +2,8 @@ package generation
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func Test_packageDir_Dir_Package(t *testing.T) {
@@ -52,6 +54,115 @@ func Test_packageDir_Dir_Package(t *testing.T) {
 			}
 			if got := tt.p.Package(); got != tt.wantPackage {
 				t.Errorf("packageDir.Dir() = %v, want %v", got, tt.wantPackage)
+			}
+		})
+	}
+}
+
+func Test_generatedRoute_SharedHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		handlerType HandlerType
+		want        bool
+	}{
+		{name: "read handler is shared", handlerType: ReadHandler, want: true},
+		{name: "list handler is shared", handlerType: ListHandler, want: true},
+		{name: "patch handler is not shared", handlerType: PatchHandler, want: false},
+		{name: "no handler type is not shared", handlerType: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := generatedRoute{HandlerType: tt.handlerType}
+			if got := g.SharedHandler(); got != tt.want {
+				t.Errorf("generatedRoute.SharedHandler() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_generatedRoute_TestMethods(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		route generatedRoute
+		want  []string
+	}{
+		{
+			name:  "read handler also tests POST",
+			route: generatedRoute{Method: "GET", HandlerType: ReadHandler},
+			want:  []string{"http.MethodGet", "http.MethodPost"},
+		},
+		{
+			name:  "list handler also tests POST",
+			route: generatedRoute{Method: "GET", HandlerType: ListHandler},
+			want:  []string{"http.MethodGet", "http.MethodPost"},
+		},
+		{
+			name:  "patch handler tests PATCH only",
+			route: generatedRoute{Method: "PATCH", HandlerType: PatchHandler},
+			want:  []string{"http.MethodPatch"},
+		},
+		{
+			name:  "rpc route tests POST only",
+			route: generatedRoute{Method: "POST"},
+			want:  []string{"http.MethodPost"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if diff := cmp.Diff(tt.want, tt.route.TestMethods()); diff != "" {
+				t.Errorf("generatedRoute.TestMethods() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_generatedRoute_appendParamsToPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		route       generatedRoute
+		wantPath    string
+		wantTestURL string
+	}{
+		{
+			name: "compound key route",
+			route: generatedRoute{
+				Path:    "/api/widget-orders",
+				TestURL: "/api/widget-orders",
+				TestParams: []routeTestParam{
+					{Key: "widgetOrderWidgetID", Value: "testWidgetOrderWidgetID"},
+					{Key: "widgetOrderOrderID", Value: "testWidgetOrderOrderID"},
+				},
+			},
+			wantPath:    "/api/widget-orders/{widgetOrderWidgetID}/{widgetOrderOrderID}",
+			wantTestURL: "/api/widget-orders/testWidgetOrderWidgetID/testWidgetOrderOrderID",
+		},
+		{
+			name: "no parameters leaves paths unchanged",
+			route: generatedRoute{
+				Path:    "/api/widgets",
+				TestURL: "/api/widgets",
+			},
+			wantPath:    "/api/widgets",
+			wantTestURL: "/api/widgets",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.route.appendParamsToPaths()
+			if tt.route.Path != tt.wantPath {
+				t.Errorf("generatedRoute.Path = %v, want %v", tt.route.Path, tt.wantPath)
+			}
+			if tt.route.TestURL != tt.wantTestURL {
+				t.Errorf("generatedRoute.TestURL = %v, want %v", tt.route.TestURL, tt.wantTestURL)
 			}
 		})
 	}


### PR DESCRIPTION
Test-route metadata is now computed at route construction instead of
being reverse-engineered from route strings:

- generatedRoute carries TestURL and TestParams; appendParamsToPaths
  derives the chi path and test URL from the same parameters, so the
  {param} placeholder and the test parameter key can no longer drift
- SharedHandler is now a method derived from HandlerType, replacing the
  redundant bool field and the `eq $route.HandlerType "readHandler"`
  magic-string comparisons in routerTestTemplate
- DetermineTestURL/DetermineParameters/MethodToHttpConst template funcs
  removed; routerTestTemplate renders one flat RouterTestRoutes slice,
  unifying the resource and computed URL building and folding the
  copy-pasted SharedHandler POST test block into a range over
  TestMethods()
- Computed test URLs/params now use the override-aware caser, and
  resource test URLs derive from the registered route path, so they
  cannot diverge under CaserInitialismOverrides

Generated output is unchanged.