### PR TITLE
fix(deps): bump remaining modules to Go 1.26.6

### DIFF
--- a/accesstypes/go.mod
+++ b/accesstypes/go.mod
@@ -1,3 +1,3 @@
 module github.com/cccteam/ccc/accesstypes
 
-go 1.26.4
+go 1.26.6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cccteam/ccc
 
-go 1.26.4
+go 1.26.6
 
 require (
 	github.com/go-playground/errors/v5 v5.4.0

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/cccteam/ccc/pkg
 
-go 1.26.4
+go 1.26.6
 
 require github.com/go-playground/errors/v5 v5.4.0
 

--- a/securehash/go.mod
+++ b/securehash/go.mod
@@ -1,6 +1,6 @@
 module github.com/cccteam/ccc/securehash
 
-go 1.26.4
+go 1.26.6
 
 require (
 	github.com/go-playground/errors/v5 v5.4.0


### PR DESCRIPTION
## Summary

Commit 6846035 bumped the `go` directive to 1.26.6 in `cache`, `middleware`, `resource`, `resource/starport`, `sns`, and `tracer` to resolve the stdlib CVEs govulncheck flagged (GO-2026-6218, GO-2026-6090, GO-2026-5972, GO-2026-5026, GO-2026-6091). Four modules were left behind on 1.26.4, which is affected by the same set:

- `go.mod` (root, `github.com/cccteam/ccc`)
- `accesstypes/go.mod`
- `pkg/go.mod`
- `securehash/go.mod`

This bumps those four, bringing every module in the repo to 1.26.6.

## Notes

No CI change is needed. `ci.yml` and `security-scan.yml` delegate to the pinned `cccteam/github-workflows` reusable workflows and set no `go-version`, so each module's `go` directive drives the toolchain. There are no Dockerfiles, `.go-version`, or `.tool-versions` files in the repo. The `resource/starport/go.work` workspace and both its member modules were already consistent at 1.26.6, so the `TestStarportApp` mismatch fixed in the prior commit does not recur.

## Test plan

- [x] `go build ./...` clean in all nine modules
- [x] `go test ./...` passes in the four changed modules (root `ok`, `accesstypes` `ok`, `securehash` `ok`, `pkg` has no test files)
- [ ] CI govulncheck confirms the five CVEs no longer report against these modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)